### PR TITLE
Adds missing python dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ mido
 Pillow
 python-rtmidi
 rpi-ws281x
+spidev


### PR DESCRIPTION
When trying to run the package I receive the ModuleNotFoundError: No
module named 'spidev' error. This is solved by installing `spidev`. I, therefore, think this dependency should be added to requirements.txt. Additionally, I also had to install NumPy but this can not be done with pip on python3. I, therefore, did not add NumPy to the requirements.txt (see[ this troubleshooting guide for more information](https://numpy.org/devdocs/user/troubleshooting-importerror.html)). After installing the NumPy deb `sudo apt install python-numpy python3-numpy` the python script could be run in python3. In python2 I also missed the `pillow` package.