### PR TITLE
Reversed Led strip

### DIFF
--- a/default_settings.xml
+++ b/default_settings.xml
@@ -71,6 +71,7 @@
 
 	<led_count>176</led_count>
 	<shift>0</shift>
+	<reverse>0</reverse>
 
 	<input_port>default</input_port>
 

--- a/menu.xml
+++ b/menu.xml
@@ -132,6 +132,9 @@
 		<LED_Strip_Settings text="Shift">
 			<Shift text="Number"></Shift>
 		</LED_Strip_Settings>
+		<LED_Strip_Settings text="Reverse">
+			<Reverse text="Number"></Reverse>
+		</LED_Strip_Settings>
 	</menu>
 	<menu text="Play MIDI">
 		<Play_MIDI text="Choose song"></Play_MIDI>

--- a/settings.xml
+++ b/settings.xml
@@ -71,6 +71,7 @@
 
 	<led_count>176</led_count>
 	<shift>0</shift>
+	<reverse>0</reverse>
 
 	<input_port>default</input_port>
 


### PR DESCRIPTION
- added reversed order mapping for the Led strip. This allows the strip to be installed from Right to Left as well (before was only possible from Left to Right)
References: #203 #142 