### PR TITLE
Fix screensaver crash

### DIFF
--- a/visualizer.py
+++ b/visualizer.py
@@ -1698,6 +1698,7 @@ def screensaver():
     download = 0
     upload_start = 0
     download_start = 0
+    local_ip = 0
 
     if (menu.screensaver_settings["local_ip"] == "1"):
         local_ip = get_ip_address()


### PR DESCRIPTION
Not actually a fix but rather a workaround. Visualizer is crashing when starting the screen saver. This is happening after a recent commit introduced a new variable local_ip

```
Traceback (most recent call last):
  File "visualizer.py", line 2399, in <module>
    menu.enter_menu()
  File "visualizer.py", line 925, in enter_menu
    menu.change_settings(self.current_choice, self.currentlocation)
  File "visualizer.py", line 1181, in change_settings
    screensaver()
  File "visualizer.py", line 1800, in screensaver
    menu.render_screensaver(hour, date, cpu_usage, round(cpu_average,1), ram_usage, temp, cpu_chart, upload, download, card_space, local_ip)
UnboundLocalError: local variable 'local_ip' referenced before assignment
```


