### PR TITLE
added key cover check in animations and pause them if closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ If you want to make your RPi autoconnect to Wi-Fi you need to follow [this guide
 ## Connecting LED Strip to Raspberry Pi and enabling SPI
 There is no point to reinvent the wheel again, here is a nice [tutorial](https://tutorials-raspberrypi.com/connect-control-raspberry-pi-ws2812-rgb-led-strips/) *(do only the hardware part)*
 
+Optionally, you can connect a switch to BCM pin 12 and GND. Attach the switch to the key cover, if available. When it is closed, the animations are automatically switched off.
+
 If you are wondering how to connect wires to RPI if screen hat is taking all pins here is a [picture](https://i.imgur.com/7KhwM7r.jpg) of how I did it. There should be a gap between RPI and screen so you can solder your wires or just wrap cables around the pins and separate them with heat shrink bands.
 
 After connecting all cables as described above everything should fit nicely to case. Scroll down to see some photos of the setup I made

--- a/lib/functions.py
+++ b/lib/functions.py
@@ -7,6 +7,9 @@ import time
 import socket
 import RPi.GPIO as GPIO
 
+SENSECOVER = 12
+GPIO.setmode(GPIO.BCM)
+GPIO.setup(SENSECOVER, GPIO.IN, GPIO.PUD_UP)
 
 def get_ip_address():
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -313,6 +316,16 @@ def theaterChase(strip, color, ledsettings, menu, wait_ms=25):
     menu.screensaver_is_running = True
 
     while menu.screensaver_is_running:
+        last_state = 1
+        cover_opened = GPIO.input(SENSECOVER)
+        while not cover_opened:
+            if last_state != cover_opened:
+                # clear if changed
+                fastColorWipe(strip, True, ledsettings)
+            time.sleep(.1)
+            last_state = cover_opened
+            cover_opened = GPIO.input(SENSECOVER)
+
         red = int(ledsettings.get_color("Red"))
         green = int(ledsettings.get_color("Green"))
         blue = int(ledsettings.get_color("Blue"))
@@ -354,6 +367,16 @@ def rainbow(strip, ledsettings, menu, wait_ms=20):
     j = 0
     menu.screensaver_is_running = True
     while menu.screensaver_is_running:
+        last_state = 1
+        cover_opened = GPIO.input(SENSECOVER)
+        while not cover_opened:
+            if last_state != cover_opened:
+                # clear if changed
+                fastColorWipe(strip, True, ledsettings)
+            time.sleep(.1)
+            last_state = cover_opened
+            cover_opened = GPIO.input(SENSECOVER)
+
         for i in range(strip.numPixels()):
             strip.setPixelColor(i, wheel(j & 255))
         j += 1
@@ -376,6 +399,16 @@ def rainbowCycle(strip, ledsettings, menu, wait_ms=20):
     j = 0
     menu.screensaver_is_running = True
     while menu.screensaver_is_running:
+        last_state = 1
+        cover_opened = GPIO.input(SENSECOVER)
+        while not cover_opened:
+            if last_state != cover_opened:
+                # clear if changed
+                fastColorWipe(strip, True, ledsettings)
+            time.sleep(.1)
+            last_state = cover_opened
+            cover_opened = GPIO.input(SENSECOVER)
+
         for i in range(strip.numPixels()):
             strip.setPixelColor(i, wheel((int(i * 256 / strip.numPixels()) + j) & 255))
         j += 1
@@ -398,6 +431,16 @@ def theaterChaseRainbow(strip, ledsettings, menu, wait_ms=25):
     j = 0
     menu.screensaver_is_running = True
     while menu.screensaver_is_running:
+        last_state = 1
+        cover_opened = GPIO.input(SENSECOVER)
+        while not cover_opened:
+            if last_state != cover_opened:
+                # clear if changed
+                fastColorWipe(strip, True, ledsettings)
+            time.sleep(.1)
+            last_state = cover_opened
+            cover_opened = GPIO.input(SENSECOVER)
+
         for q in range(5):
             for i in range(0, strip.numPixels(), 5):
                 strip.setPixelColor(i + q, wheel((i + j) % 255))
@@ -425,6 +468,16 @@ def breathing(strip, ledsettings, menu, wait_ms=2):
     multiplier = 24
     direction = 2
     while menu.screensaver_is_running:
+        last_state = 1
+        cover_opened = GPIO.input(SENSECOVER)
+        while not cover_opened:
+            if last_state != cover_opened:
+                # clear if changed
+                fastColorWipe(strip, True, ledsettings)
+            time.sleep(.1)
+            last_state = cover_opened
+            cover_opened = GPIO.input(SENSECOVER)
+
         if multiplier >= 98 or multiplier < 24:
             direction *= -1
         multiplier += direction
@@ -454,6 +507,16 @@ def sound_of_da_police(strip, ledsettings, menu, wait_ms=5):
     r_start = 0
     l_start = 196
     while menu.screensaver_is_running:
+        last_state = 1
+        cover_opened = GPIO.input(SENSECOVER)
+        while not cover_opened:
+            if last_state != cover_opened:
+                # clear if changed
+                fastColorWipe(strip, True, ledsettings)
+            time.sleep(.1)
+            last_state = cover_opened
+            cover_opened = GPIO.input(SENSECOVER)
+
         r_start += 14
         l_start -= 14
         for i in range(strip.numPixels()):
@@ -489,6 +552,16 @@ def scanner(strip, ledsettings, menu, wait_ms=1):
     green_fixed = ledsettings.get_color("Green")
     blue_fixed = ledsettings.get_color("Blue")
     while menu.screensaver_is_running:
+        last_state = 1
+        cover_opened = GPIO.input(SENSECOVER)
+        while not cover_opened:
+            if last_state != cover_opened:
+                # clear if changed
+                fastColorWipe(strip, True, ledsettings)
+            time.sleep(.1)
+            last_state = cover_opened
+            cover_opened = GPIO.input(SENSECOVER)
+
         position += direction
         for i in range(strip.numPixels()):
             if i > (position - scanner_length) and i < (position + scanner_length):


### PR DESCRIPTION
I added an optional feature for users with pianos featuring a key cover. Users may add a switch (magnetic, mechanical, etc.) that detects if the cover is opened or closed. If it is closed, the strip will be cleared and the animation paused.

**Explanation**
I came up with this idea, because I am using this project also for ambient room lighting and I just wanted to open up the piano without having to start the animation manually. Just breaking the SPI data line with a switch was not an optimal solution, because the PI would still calculate the animation and try to push the information via the SPI pin. Thus this solution reduces the power consumption at idle state.

**How to connect**
I used pin 12 (BCM naming style) for the switch. It is the fifth pin from the other end on the same pin row, where the SPI pin is located as well. GND can be used from the LED strip or via a separate connection. Pin 12 is surrounded by two GND pins, so it is up to you to choose from. 
The specific implementation depends on the piano. In my case I used a magnetic reed switch, but mechanical switches can be used as well.

**Files modified**
- lib/functions.py: Each animation has its own check inside. 
- README.md: Addes short documentation on how to connect the switch.

I tested all animations via web interface and display and everything works as expected. Adding this is completely optional, because a missing switch is considered as key cover open.