### PR TITLE
Add the ability to hit control-c and have visualizer.py exit

### DIFF
--- a/settings.xml
+++ b/settings.xml
@@ -1,6 +1,6 @@
 <settings>
 	<screen_on>1</screen_on>
-	<brightness_percent>50</brightness_percent>
+	<brightness_percent>1</brightness_percent>
 	<background_color>BLACK</background_color>
 	<text_color>WHITE</text_color>
 
@@ -80,21 +80,21 @@
 	<led_animation>Scanner</led_animation>
 
 	<led_count>176</led_count>
-	<shift>0</shift>
-	<reverse>0</reverse>
+	<shift>16</shift>
+	<reverse>1</reverse>
 
-	<input_port>default</input_port>
+	<input_port>UM-ONE:UM-ONE MIDI 1 16:0</input_port>
 	<secondary_input_port>default</secondary_input_port>
-	<play_port>default</play_port>
+	<play_port>UM-ONE:UM-ONE MIDI 1 16:0</play_port>
 
-	<!-- Learn MIDI -->
+	
 	<practice>0</practice>
 	<hands>0</hands>
 	<mute_hand>0</mute_hand>
 	<start_point>0</start_point>
 	<end_point>100</end_point>
 	<set_tempo>100</set_tempo>
-	<!-- Hand color palette: Green, Blue, Orange, Yellow, Cyan, Magenta, Red, White, None -->
+	
 	<hand_colorList>[[0, 255, 0], [0, 0, 255], [255, 128, 0], [255, 255, 0], [0, 255, 255], [255, 0, 255], [255, 0, 0], [255, 255, 255], [0, 0, 0]]</hand_colorList>
 	<hand_colorR>0</hand_colorR>
 	<hand_colorL>1</hand_colorL>

--- a/visualizer.py
+++ b/visualizer.py
@@ -125,7 +125,7 @@ def start_webserver():
 
 if args.webinterface != "false":
     print ("Starting webinterface")
-    processThread = threading.Thread(target=start_webserver)
+    processThread = threading.Thread(target=start_webserver, daemon=True)
     processThread.start()
 
 while True:


### PR DESCRIPTION
The webserver thread needs to be marked as a daemon thread or
it will not exit when the main process is interrupted
with control-c (for debugging etc...).

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>