### PR TITLE
Add the ability to hit control-c and have visualizer.py exit

### DIFF
--- a/visualizer.py
+++ b/visualizer.py
@@ -125,7 +125,7 @@ def start_webserver():
 
 if args.webinterface != "false":
     print ("Starting webinterface")
-    processThread = threading.Thread(target=start_webserver)
+    processThread = threading.Thread(target=start_webserver, daemon=True)
     processThread.start()
 
 while True:


### PR DESCRIPTION
The webserver thread needs to be marked as a daemon thread or
it will not exit when the main process is interrupted
with control-c (for debugging etc...).

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>