### PR TITLE
Add /sbin/ prefix to shutdown and reboot commands

### DIFF
--- a/lib/menulcd.py
+++ b/lib/menulcd.py
@@ -939,14 +939,14 @@ class MenuLCD:
         if location == "Shutdown":
             if choice == "Confirm":
                 self.render_message("", "Shutting down...", 5000)
-                call("sudo shutdown -h now", shell=True)
+                call("sudo /sbin/shutdown -h now", shell=True)
             else:
                 self.go_back()
 
         if location == "Reboot":
             if choice == "Confirm":
                 self.render_message("", "Rebooting...", 5000)
-                call("sudo reboot now", shell=True)
+                call("sudo /sbin/reboot now", shell=True)
             else:
                 self.go_back()
 

--- a/webinterface/views_api.py
+++ b/webinterface/views_api.py
@@ -845,10 +845,10 @@ def change_setting():
         webinterface.usersettings.reset_to_default()
 
     if setting_name == "restart_rpi":
-        call("sudo reboot now", shell=True)
+        call("sudo /sbin/reboot now", shell=True)
 
     if setting_name == "turnoff_rpi":
-        call("sudo shutdown -h now", shell=True)
+        call("sudo /sbin/shutdown -h now", shell=True)
 
     if setting_name == "update_rpi":
         call("sudo git reset --hard HEAD", shell=True)


### PR DESCRIPTION
If not using Rasbian and using a non-root account, /sbin is not in the
PATH variable and command will not be found.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>