### PR TITLE
Fix stack trace for web interface saving on the sequence tab

### DIFF
--- a/webinterface/views_api.py
+++ b/webinterface/views_api.py
@@ -606,7 +606,7 @@ def change_setting():
         return jsonify(success=True, reload_sequence=reload_sequence)
 
     # saving current led settings as sequence step
-    if setting_name == "save_led_settings_to_step":
+    if setting_name == "save_led_settings_to_step" and second_value != "":
 
         # remove node and child under "sequence_" + str(value) and "step_" + str(second_value)
         sequences_tree = minidom.parse("sequences.xml")


### PR DESCRIPTION
ERROR:webinterface:Exception on /api/change_setting [GET]
Traceback (most recent call last):
  File "/home/pi/.local/lib/python3.10/site-packages/flask/app.py", line 2073, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/pi/.local/lib/python3.10/site-packages/flask/app.py", line 1518, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/pi/.local/lib/python3.10/site-packages/flask/app.py", line 1516, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/pi/.local/lib/python3.10/site-packages/flask/app.py", line 1502, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args)
  File "/var/home/pi/Piano-LED-Visualizer/webinterface/views_api.py", line 633, in change_setting
    second_value = int(second_value)
ValueError: invalid literal for int() with base 10: ''

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>