### PR TITLE
Add the ability to modify the note offsets the UI/LCD

### DIFF
--- a/default_settings.xml
+++ b/default_settings.xml
@@ -64,6 +64,8 @@
 
 	<skipped_notes>None</skipped_notes>
 
+	<note_offsets>[[92, 2], [55, 1]]</note_offsets>
+
 	<time>1</time>
 	<date>1</date>
 	<cpu_chart>1</cpu_chart>

--- a/lib/functions.py
+++ b/lib/functions.py
@@ -256,13 +256,13 @@ def screensaver(menu, midiports, saving, ledstrip, ledsettings):
 
 
 # Get note position on the strip
-def get_note_position(note, ledstrip):
-    if note > 92:
-        note_offset = 2
-    elif note > 55:
-        note_offset = 1
-    else:
-        note_offset = 0
+def get_note_position(note, ledstrip, ledsettings):
+    note_offsets = ledsettings.note_offsets
+    note_offset = 0
+    for i in range(0, len(note_offsets)):
+        if note > note_offsets[i][0]:
+            note_offset = note_offsets[i][1]
+            break
     note_offset -= ledstrip.shift
     note_pos_raw = 2 * (note - 20) - note_offset
     if ledstrip.reverse:

--- a/lib/learnmidi.py
+++ b/lib/learnmidi.py
@@ -210,7 +210,7 @@ class LearnMIDI:
                 if not msg.is_meta:
                     # Calculate note position on the strip and display
                     if msg.type == 'note_on' or msg.type == 'note_off':
-                        note_position = get_note_position(msg.note, self.ledstrip)
+                        note_position = get_note_position(msg.note, self.ledstrip, self.ledsettings)
                         brightness = msg.velocity / 127
                         if msg.channel == 1:
                             red = int(self.hand_colorList[self.hand_colorR][0] * brightness)

--- a/lib/ledsettings.py
+++ b/lib/ledsettings.py
@@ -125,7 +125,8 @@ class LedSettings:
         self.usersettings.change_setting_value("multicolor", self.multicolor)
         self.usersettings.change_setting_value("multicolor_range", self.multicolor_range)
 
-        # self.menu.update_multicolor(self.multicolor)
+        self.menu.update_multicolor(self.multicolor)
+        self.menu.show()
 
     def deletecolor(self, key):
         del self.multicolor[int(key) - 1]
@@ -134,8 +135,9 @@ class LedSettings:
         self.usersettings.change_setting_value("multicolor", self.multicolor)
         self.usersettings.change_setting_value("multicolor_range", self.multicolor_range)
 
-        # self.menu.update_multicolor(self.multicolor)
+        self.menu.update_multicolor(self.multicolor)
         self.menu.go_back()
+        self.menu.show()
 
     def change_multicolor(self, choice, location, value):
         self.sequence_active = False

--- a/lib/ledsettings.py
+++ b/lib/ledsettings.py
@@ -92,6 +92,24 @@ class LedSettings:
         self.ledstrip = ledstrip
         menu.update_multicolor(self.multicolor)
 
+    def add_note_offset(self):
+        self.note_offsets.insert(0, [100, 1])
+        self.usersettings.change_setting_value("note_offsets", self.note_offsets)
+
+    def append_note_offset(self):
+        self.note_offsets.append([1, 1])
+        self.usersettings.change_setting_value("note_offsets", self.note_offsets)
+
+    def del_note_offset(self, slot):
+        del self.note_offsets[int(slot) - 1]
+        self.usersettings.change_setting_value("note_offsets", self.note_offsets)
+
+    def update_note_offset(self, slot, data):
+        pair = data.split(",")
+        self.note_offsets[int(slot) - 1][0] = int(pair[0])
+        self.note_offsets[int(slot) - 1][1] = int(pair[1])
+        self.usersettings.change_setting_value("note_offsets", self.note_offsets)
+
     def addcolor(self):
         self.multicolor.append([0, 255, 0])
         self.multicolor_range.append([20, 108])

--- a/lib/ledsettings.py
+++ b/lib/ledsettings.py
@@ -110,6 +110,14 @@ class LedSettings:
         self.note_offsets[int(slot) - 1][1] = int(pair[1])
         self.usersettings.change_setting_value("note_offsets", self.note_offsets)
 
+    def update_note_offset_lcd(self, current_choice, currentlocation, value):
+        slot = int(currentlocation.replace('Offset', '')) - 1
+        if current_choice == "LED Number":
+            self.note_offsets[slot][0] += value
+        else:
+            self.note_offsets[slot][1] += value
+        self.usersettings.change_setting_value("note_offsets", self.note_offsets)
+
     def addcolor(self):
         self.multicolor.append([0, 255, 0])
         self.multicolor_range.append([20, 108])

--- a/lib/ledsettings.py
+++ b/lib/ledsettings.py
@@ -41,6 +41,8 @@ class LedSettings:
 
         self.skipped_notes = usersettings.get_setting_value("skipped_notes")
 
+        self.note_offsets = ast.literal_eval(usersettings.get_setting_value("note_offsets"))
+
         self.notes_in_last_period = []
         self.speed_period_in_seconds = 0.8
 

--- a/lib/menulcd.py
+++ b/lib/menulcd.py
@@ -106,6 +106,12 @@ class MenuLCD:
             load_song_mc.appendChild(element)
 
     def update_sequence_list(self):
+        seq_mc = self.DOMTree.createElement("LED_Strip_Settings")
+        seq_mc.appendChild(self.DOMTree.createTextNode(""))
+        seq_mc.setAttribute("text", "Sequences")
+        mc = self.DOMTree.getElementsByTagName("Sequences")[0]
+        mc.parentNode.parentNode.replaceChild(seq_mc, mc.parentNode)
+        ret = True
         try:
             sequences_tree = minidom.parse("sequences.xml")
             self.update_songs()
@@ -120,18 +126,33 @@ class MenuLCD:
                     element = self.DOMTree.createElement("Sequences")
                     element.appendChild(self.DOMTree.createTextNode(""))
                     element.setAttribute("text", str(sequence_name))
-                    mc = self.DOMTree.getElementsByTagName("LED_Strip_Settings")[0]
-                    mc.appendChild(element)
-
+                    seq_mc.appendChild(element)
                 except:
                     break
         except:
-            self.render_message("Something went wrong", "Check your sequences file", 1500)
+            ret = False
+        element = self.DOMTree.createElement("Sequences")
+        element.appendChild(self.DOMTree.createTextNode(""))
+        element.setAttribute("text", "Update")
+        seq_mc.appendChild(element)
+        return ret
 
     def update_ports(self):
         ports = mido.get_input_names()
         ports = list(dict.fromkeys(ports))
         self.update_sequence_list()
+        # Replace Input and Playback with empty elements
+        element = self.DOMTree.createElement("Ports_Settings")
+        element.appendChild(self.DOMTree.createTextNode(""))
+        element.setAttribute("text", "Input")
+        mc = self.DOMTree.getElementsByTagName("Ports_Settings")[0]
+        mc.parentNode.replaceChild(element, mc)
+        element = self.DOMTree.createElement("Ports_Settings")
+        element.appendChild(self.DOMTree.createTextNode(""))
+        element.setAttribute("text", "Playback")
+        mc = self.DOMTree.getElementsByTagName("Ports_Settings")[1]
+        mc.parentNode.replaceChild(element, mc)
+
         for port in ports:
             element = self.DOMTree.createElement("Input")
             element.appendChild(self.DOMTree.createTextNode(""))
@@ -142,7 +163,7 @@ class MenuLCD:
             element = self.DOMTree.createElement("Playback")
             element.appendChild(self.DOMTree.createTextNode(""))
             element.setAttribute("text", port)
-            mc = self.DOMTree.getElementsByTagName("Ports_Settings")[2]
+            mc = self.DOMTree.getElementsByTagName("Ports_Settings")[1]
             mc.appendChild(element)
 
     def update_led_note_offsets(self):
@@ -999,6 +1020,7 @@ class MenuLCD:
                 refresh_result = self.update_sequence_list()
                 if not refresh_result:
                     self.render_message("Something went wrong", "Make sure your sequence file is correct", 1500)
+                self.show()
             else:
                 self.ledsettings.set_sequence(self.pointer_position, 0)
 

--- a/lib/menulcd.py
+++ b/lib/menulcd.py
@@ -2,6 +2,7 @@ import os
 
 from subprocess import call
 from xml.dom import minidom
+from lib.ledsettings import LedSettings
 
 import webcolors as wc
 from PIL import ImageFont, Image, ImageDraw
@@ -185,14 +186,20 @@ class MenuLCD:
         i = 0
         self.update_ports()
         rgb_names = ["Red", "Green", "Blue"]
+        mc = self.DOMTree.getElementsByTagName("Multicolor")[0]
+        mc_multicolor = self.DOMTree.createElement("LED_Color")
+        mc_multicolor.appendChild(self.DOMTree.createTextNode(""))
+        mc_multicolor.setAttribute("text", "Multicolor")
+        parent = mc.parentNode.parentNode
+        parent.replaceChild(mc_multicolor, mc.parentNode)
         for color in colors_list:
             i = i + 1
 
             element = self.DOMTree.createElement("Multicolor")
             element.appendChild(self.DOMTree.createTextNode(""))
             element.setAttribute("text", "Color" + str(i))
-            mc = self.DOMTree.getElementsByTagName("LED_Color")[0]
-            mc.appendChild(element)
+            #mc = self.DOMTree.getElementsByTagName("LED_Color")[0]
+            mc_multicolor.appendChild(element)
 
             element = self.DOMTree.createElement("Color" + str(i))
             element.appendChild(self.DOMTree.createTextNode(""))
@@ -232,6 +239,11 @@ class MenuLCD:
                 element.setAttribute("text", rgb_name)
                 mc = self.DOMTree.getElementsByTagName("Color" + str(i))[0]
                 mc.appendChild(element)
+        # Add in the Add Color from the replaced child
+        element = self.DOMTree.createElement("Multicolor")
+        element.appendChild(self.DOMTree.createTextNode(""))
+        element.setAttribute("text", "Add Color")
+        mc_multicolor.appendChild(element)
 
     def scale(self, size):
         return int(round(size * self.LCD.font_scale))

--- a/lib/menulcd.py
+++ b/lib/menulcd.py
@@ -260,10 +260,14 @@ class MenuLCD:
                 element.setAttribute("text", rgb_name)
                 mc = self.DOMTree.getElementsByTagName("Color" + str(i))[0]
                 mc.appendChild(element)
-        # Add in the Add Color from the replaced child
+        # Add in the "Add Color" and "Confirm" into the replaced child
         element = self.DOMTree.createElement("Multicolor")
         element.appendChild(self.DOMTree.createTextNode(""))
         element.setAttribute("text", "Add Color")
+        mc_multicolor.appendChild(element)
+        element = self.DOMTree.createElement("Multicolor")
+        element.appendChild(self.DOMTree.createTextNode(""))
+        element.setAttribute("text", "Confirm")
         mc_multicolor.appendChild(element)
 
     def scale(self, size):

--- a/lib/menulcd.py
+++ b/lib/menulcd.py
@@ -33,7 +33,6 @@ class MenuLCD:
         self.image = Image.new("RGB", (self.LCD.width, self.LCD.height), "GREEN")
         self.draw = ImageDraw.Draw(self.image)
         self.LCD.LCD_ShowImage(self.image, 0, 0)
-        self.xml_file_name = xml_file_name
         self.DOMTree = minidom.parse(xml_file_name)
         self.currentlocation = "menu"
         self.scroll_hold = 0
@@ -79,21 +78,30 @@ class MenuLCD:
             self.screensaver_settings[setting] = "1"
 
     def update_songs(self):
+        # Assume the first node is "Choose song"
+        replace_node = self.DOMTree.getElementsByTagName("Play_MIDI")[0]
+        choose_song_mc = self.DOMTree.createElement("Play_MIDI")
+        choose_song_mc.appendChild(self.DOMTree.createTextNode(""))
+        choose_song_mc.setAttribute("text", "Choose song")
+        replace_node.parentNode.replaceChild(choose_song_mc, replace_node)
+        # Assume the first node is "Load song"
+        replace_node = self.DOMTree.getElementsByTagName("Learn_MIDI")[0]
+        load_song_mc = self.DOMTree.createElement("Learn_MIDI")
+        load_song_mc.appendChild(self.DOMTree.createTextNode(""))
+        load_song_mc.setAttribute("text", "Load song")
+        replace_node.parentNode.replaceChild(load_song_mc, replace_node)
         songs_list = os.listdir("Songs")
-        self.DOMTree = minidom.parse(self.xml_file_name)
         for song in songs_list:
             # List of songs for Play_MIDI
             element = self.DOMTree.createElement("Choose_song")
             element.appendChild(self.DOMTree.createTextNode(""))
             element.setAttribute("text", song)
-            mc = self.DOMTree.getElementsByTagName("Play_MIDI")[0]
-            mc.appendChild(element)
+            choose_song_mc.appendChild(element)
             # List of songs for Learn_MIDI
             element = self.DOMTree.createElement("Load_song")
             element.appendChild(self.DOMTree.createTextNode(""))
             element.setAttribute("text", song)
-            mc = self.DOMTree.getElementsByTagName("Learn_MIDI")[0]
-            mc.appendChild(element)
+            load_song_mc.appendChild(element)
 
     def update_sequence_list(self):
         try:

--- a/lib/menulcd.py
+++ b/lib/menulcd.py
@@ -871,7 +871,7 @@ class MenuLCD:
 
         if location == "Other_Settings":
             if choice == "System Info":
-                screensaver(self, self.midiports, self.saving, self.ledstrip)
+                screensaver(self, self.midiports, self.saving, self.ledstrip, self.ledsettings)
 
         if location == "Rainbow_Colors":
             self.ledsettings.color_mode = "Rainbow"

--- a/menu.xml
+++ b/menu.xml
@@ -149,6 +149,9 @@
 		<LED_Strip_Settings text="Reverse">
 			<Reverse text="Number"></Reverse>
 		</LED_Strip_Settings>
+		<LED_Strip_Settings text="LED Note Offsets">
+			<LED_Note_Offsets text="Add Note Offset"></LED_Note_Offsets>
+		</LED_Strip_Settings>
 	</menu>
 	<menu text="Play MIDI">
 		<Play_MIDI text="Choose song"></Play_MIDI>

--- a/menu.xml
+++ b/menu.xml
@@ -25,7 +25,6 @@
 			</LED_Color>
 			<LED_Color text="Multicolor">
 				<Multicolor text="Add Color"></Multicolor>
-				<Multicolor text="Confirm"></Multicolor>
 			</LED_Color>			
 			<LED_Color text="Rainbow Colors">
 				<Rainbow_Colors text="Offset"></Rainbow_Colors>

--- a/settings.xml
+++ b/settings.xml
@@ -64,6 +64,8 @@
 
 	<skipped_notes>None</skipped_notes>
 
+	<note_offsets>[[92, 2], [55, 1]]</note_offsets>
+
 	<time>1</time>
 	<date>1</date>
 	<cpu_chart>1</cpu_chart>

--- a/visualizer.py
+++ b/visualizer.py
@@ -318,7 +318,7 @@ while True:
                     pass
 
         # changing offset to adjust the distance between the LEDs to the key spacing
-        note_position = get_note_position(note, ledstrip)
+        note_position = get_note_position(note, ledstrip, ledsettings)
 
         if (note_position > ledstrip.led_number or note_position < 0) and control_change is False:
             continue

--- a/webinterface/static/index.js
+++ b/webinterface/static/index.js
@@ -271,6 +271,8 @@ function get_settings(home = true) {
 
                 show_multicolors(response.multicolor, response.multicolor_range);
 
+                show_note_offsets(response.note_offsets);
+
                 document.getElementById("rainbow_offset").value = response.rainbow_offset;
                 document.getElementById("rainbow_scale").value = response.rainbow_scale;
                 document.getElementById("rainbow_timeshift").value = response.rainbow_timeshift;
@@ -1212,6 +1214,64 @@ function show_multicolors(colors, ranges) {
     }
     if (i >= 3) {
         multicolor_element.innerHTML += add_button;
+    }
+}
+
+function show_note_offsets(note_offsets) {
+    try {
+        note_offsets = JSON.parse(note_offsets);
+    } catch (e) {
+    }
+
+    offset_element = document.getElementById("NoteOffsetEntry");
+    var i = 0
+    offset_element.innerHTML = "";
+    var add_button = "<button onclick=\"this.classList.add('hidden');this.nextElementSibling.classList.remove('hidden')\" " +
+        "id=\"note_offsets_add\" class=\"w-full outline-none mb-2 bg-gray-100 dark:bg-gray-600 font-bold h-6 py-2 px-2 " +
+        "rounded-2xl inline-flex items-center\">\n" +
+        "   <svg xmlns=\"http://www.w3.org/2000/svg\" class=\"h-6 w-full justify-items-center text-green-400\" " +
+        "fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\">\n" +
+        "      <path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M12 9v3m0 " +
+        "0v3m0-3h3m-3 0H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z\"></path>\n" +
+        "   </svg>\n" +
+        "</button>\n" +
+        "<button onclick=\"change_setting('add_note_offset', '0')\" id=\"note_offsets_add\" " +
+        "class=\"hidden w-full outline-none mb-2 bg-gray-100 dark:bg-gray-600 font-bold h-6 py-2 px-2 " +
+        "rounded-2xl inline-flex items-center\">\n" +
+        "<span class=\"w-full text-green-400\">Click to confirm</span></button>"
+    offset_element.classList.remove("pointer-events-none", "opacity-50");
+    offset_element.innerHTML += add_button;
+    for (const element of note_offsets) {
+        offset_element.innerHTML += '<div class="mb-2 bg-gray-100 dark:bg-gray-600" id="noteoffset_' + i + '">' +
+            '<label class="ml-2 inline block uppercase tracking-wide text-xs font-bold mt-2 text-gray-600 dark:text-gray-400">\n' +
+            '                    Note Offset ' + parseInt(i + 1) + '\n' +
+            '                </label><div onclick=\'this.classList.add("hidden");' +
+            'this.nextElementSibling.classList.remove("hidden")\' class="inline float-right text-red-400">' +
+            '<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">\n' +
+            '  <path stroke-linecap="round" stroke-linejoin="round" ' +
+            'stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 ' +
+            '4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />\n' +
+            '</svg>' +
+            '</div><div onclick=\'change_setting("remove_note_offset", "' + i + '");' +
+            'document.getElementById("NoteOffsetEntry").classList.add("pointer-events-none","opacity-50")\' ' +
+            'class="hidden inline float-right text-red-400">Click to confirm</div>' +
+            '                <div id="note_offset_' + i + '" class="justify-center flex" ' +
+            'onchange=\'change_setting("update_note_offset", "' + i + '", document.getElementById("note_offset_' + i + '_num").value' +
+            '                          + "," + document.getElementById("note_offset_' + i + '_off").value);\'>\n' +
+            '                    <span class="w-1/20 h-6 px-2 bg-gray-100 dark:bg-gray-600 text-red-400">Light Number:</span>\n' +
+            '                    <input id="note_offset_' + i + '_num" type="number" value="' + element[0] + '" min="0" max="255"\n' +
+            '                           class="w-2/12 h-6 bg-gray-100 dark:bg-gray-600" onkeyup=enforceMinMax(this)>\n' +
+            '                    <span class="w-1/20 h-6 px-2 bg-gray-100 dark:bg-gray-600 text-green-400">Offset:</span>\n' +
+            '                    <input id="note_offset_' + i + '_off" type="number" value="' + element[1] + '" min="0" max="255"\n' +
+            '                           class="w-2/12 h-6 bg-gray-100 dark:bg-gray-600" onkeyup=enforceMinMax(this)>\n' +
+            '                </div>' +
+            '               </div>';
+        i++;
+    }
+    if (i >= 1) {
+        end_button = add_button.replace("add_note_offset", "append_note_offset")
+        end_button = end_button.replace("note_offsets_add", "note_offsets_add2")
+        offset_element.innerHTML += end_button;
     }
 }
 

--- a/webinterface/templates/ledsettings.html
+++ b/webinterface/templates/ledsettings.html
@@ -160,6 +160,16 @@ grid sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4
         </div>
 
     </div>
+
+    <div class="flex-1 p-5 bg-gray-200 dark:bg-gray-700 shadow-xl rounded-lg">
+        <div class="flex">
+            <div class="flex-1 font-bold text-xl pb-2 text-gray-600 dark:text-gray-400">LED Note Offsets</div>
+        </div>
+        <div class="overflow-y-auto overflow-x-hidden max-h-80">
+            <div id="NoteOffsetEntry" class="flex-1">
+            </div>
+        </div>
+    </div>
 </div>
 
 

--- a/webinterface/views_api.py
+++ b/webinterface/views_api.py
@@ -231,6 +231,25 @@ def change_setting():
         webinterface.usersettings.change_setting_value("skipped_notes", value)
         webinterface.ledsettings.skipped_notes = value
 
+    if setting_name == "add_note_offset":
+        webinterface.ledsettings.add_note_offset()
+        return jsonify(success=True, reload=True)
+
+    if setting_name == "append_note_offset":
+        webinterface.ledsettings.append_note_offset()
+        return jsonify(success=True, reload=True)
+
+    if setting_name == "remove_note_offset":
+        webinterface.ledsettings.del_note_offset(int(value) + 1)
+        return jsonify(success=True, reload=True)
+
+    if setting_name == "note_offsets":
+        webinterface.usersettings.change_setting_value("note_offsets", value)
+
+    if setting_name == "update_note_offset":
+        webinterface.ledsettings.update_note_offset(int(value) + 1, second_value)
+        return jsonify(success=True, reload=True)
+
     if setting_name == "led_count":
         webinterface.usersettings.change_setting_value("led_count", int(value))
         webinterface.ledstrip.change_led_count(int(value), True)
@@ -1058,6 +1077,7 @@ def get_settings():
     response["play_port"] = webinterface.usersettings.get_setting_value("play_port")
 
     response["skipped_notes"] = webinterface.usersettings.get_setting_value("skipped_notes")
+    response["note_offsets"] = webinterface.usersettings.get_setting_value("note_offsets")
     response["led_count"] = webinterface.usersettings.get_setting_value("led_count")
     response["led_shift"] = webinterface.usersettings.get_setting_value("shift")
     response["led_reverse"] = webinterface.usersettings.get_setting_value("reverse")


### PR DESCRIPTION
The ability to customize the note offsets without modifying the code
is highly desirable.

In the process of adding the feature to modify the note_offsets in the
LCD panel I discovered a number of other problems.  These all had to
get fixed in order for the note_offsets editing to work properly with
all the other features.

To enable dynamic XML changes, update_songs() had to have the following
removed:

   self.DOMTree = minidom.parse(self.xml_file_name)

The replacement of the of the base tree was erasing any of the dynamic
updates to the xml tree nodes.  This enabled the ability to add the
note_offsets editor, but caused the need for additional fixes because
the other update functions just kept on appending new data as you
interact with the LCD menu.  For example, the Multicolor menu didn't
work properly before this change and was much worse after the change.
This patch set fixes it to work dynamically so you no longer after to
restart the visualizer.
