### PR TITLE
rounding speed_period_in_seconds on editing to keep them in a .1 step size

### DIFF
--- a/lib/menulcd.py
+++ b/lib/menulcd.py
@@ -1165,7 +1165,8 @@ class MenuLCD:
                                                    self.ledsettings.speed_fastest[self.current_choice.lower()])
 
         if self.currentlocation == "Period":
-            self.ledsettings.speed_period_in_seconds += (value / float(10)) * self.speed_multiplier
+            self.ledsettings.speed_period_in_seconds = round(self.ledsettings.speed_period_in_seconds + (value * .1) *
+                                                             self.speed_multiplier, 1)
             if self.ledsettings.speed_period_in_seconds < 0.1:
                 self.ledsettings.speed_period_in_seconds = 0.1
             self.usersettings.change_setting_value("speed_period_in_seconds", self.ledsettings.speed_period_in_seconds)

--- a/lib/menulcd.py
+++ b/lib/menulcd.py
@@ -523,7 +523,7 @@ class MenuLCD:
 
         # displaying speed values
         if self.currentlocation == "Period":
-            self.draw.text((self.scale(10), self.scale(70)), str(self.ledsettings.speed_period_in_seconds),
+            self.draw.text((self.scale(10), self.scale(70)), f"{self.ledsettings.speed_period_in_seconds:.1f}",
                            fill=self.text_color, font=self.font)
 
         if self.currentlocation == "Max_notes_in_period":

--- a/lib/menulcd.py
+++ b/lib/menulcd.py
@@ -622,7 +622,7 @@ class MenuLCD:
 
         # displaying speed values
         if self.currentlocation == "Period":
-            self.draw.text((self.scale(10), self.scale(70)), f"{self.ledsettings.speed_period_in_seconds:.1f}",
+            self.draw.text((self.scale(10), self.scale(70)), str(self.ledsettings.speed_period_in_seconds),
                            fill=self.text_color, font=self.font)
 
         if self.currentlocation == "Max_notes_in_period":


### PR DESCRIPTION
Editing the period attribute in the speed LED mode had some display issues due to .1 not being representable exactly in binary form (see image). I tried formatting first, but this had some issues:
- value saved in settings.xml was not bound to .1 steps
- value in web interface required formatting as well

Rounding should be more straightforward and less error prone.
I am happy to contribute again :)

![20220108_122633](https://user-images.githubusercontent.com/62506842/148654709-d68bfc8c-7a73-41a2-9435-3499fc65502a.jpg)
