### PR TITLE
Improve the connectall and rtpmidid network connection reliability

### DIFF
--- a/Docs/manual_installation.md
+++ b/Docs/manual_installation.md
@@ -14,46 +14,37 @@ After succesfully booting RPi (and connecting to it by SSH if necessary) we need
 
 ### 2. **Creating autoconnect script** ### 
 *You can skip this part if you don't plan to connect any MIDI device other than a piano.*
-- Create `connectall.rb` file
+- Create `connectall.py` file
 
- `sudo nano /usr/local/bin/connectall.rb`
+ `sudo nano /usr/local/bin/connectall.py`
 - paste the script:
-```ruby
-#!/usr/bin/ruby
+```python
+#!/usr/bin/python3
+import subprocess
 
-t = `aconnect -i -l`
-$devices = {}
-$device = 0
-t.lines.each do |l|
-  match = /client (\d*)\:((?:(?!client).)*)?/.match(l)
-  # we skip empty lines and the "Through" port
-  unless match.nil? || match[1] == '0' || /Through/=~l
-    $device = match[1]
-    $devices[$device] = []
-  end
-  match = /^\s+(\d+)\s/.match(l)
-  if !match.nil? && !$devices[$device].nil?
-    $devices[$device] << match[1]
-  end
-end
-
-$devices.each do |device1, ports1|
-  ports1.each do |port1|
-    $devices.each do |device2, ports2|
-      ports2.each do |port2|
-        # probably not a good idea to connect a port to itself
-        unless device1 == device2 && port1 == port2 
-          system "aconnect #{device1}:#{port1} #{device2}:#{port2}"
-        end
-      end
-    end
-  end
-end
+ports = subprocess.check_output(["aconnect", "-i", "-l"], text=True)
+port_list = []
+client = "0"
+for line in str(ports).splitlines():
+    if line.startswith("client "):
+        client = line[7:].split(":",2)[0]
+        if client == "0" or "Through" in line:
+            client = "0"
+    else:
+        if client == "0" or line.startswith('\t'):
+            continue
+        port = line.split()[0]
+        port_list.append(client+":"+port)
+ for source in port_list:
+    for target in port_list:
+        if source != target:
+            #print("aconnect %s %s" % (source, target))
+            subprocess.call("aconnect %s %s" % (source, target), shell=True)
 ```
 Press CTRL + O to save file, confirm with enter and CTRL + X to exit editor.
 - Change permissions:
 
-    `sudo chmod +x /usr/local/bin/connectall.rb`
+    `sudo chmod +x /usr/local/bin/connectall.py`
 
 - Make the script launch on USB connect:
 
@@ -61,7 +52,7 @@ Press CTRL + O to save file, confirm with enter and CTRL + X to exit editor.
 
 - Paste and save:
 
-    `ACTION=="add|remove", SUBSYSTEM=="usb", DRIVER=="usb", RUN+="/usr/local/bin/connectall.rb"  `
+    `ACTION=="add|remove", SUBSYSTEM=="usb", DRIVER=="usb", RUN+="/usr/local/bin/connectall.py"  `
 
 - Reload services:
 
@@ -76,7 +67,7 @@ Press CTRL + O to save file, confirm with enter and CTRL + X to exit editor.
 Description=Initial USB MIDI connect
 
 [Service]
-ExecStart=/usr/local/bin/connectall.rb
+ExecStart=/usr/local/bin/connectall.py
 
 [Install]
 WantedBy=multi-user.target

--- a/Docs/manual_installation.md
+++ b/Docs/manual_installation.md
@@ -35,7 +35,7 @@ for line in str(ports).splitlines():
             continue
         port = line.split()[0]
         port_list.append(client+":"+port)
- for source in port_list:
+for source in port_list:
     for target in port_list:
         if source != target:
             #print("aconnect %s %s" % (source, target))

--- a/connectall.py
+++ b/connectall.py
@@ -1,0 +1,21 @@
+#!/usr/bin/python3
+import subprocess
+
+ports = subprocess.check_output(["aconnect", "-i", "-l"], text=True)
+port_list = []
+client = "0"
+for line in str(ports).splitlines():
+    if line.startswith("client "):
+        client = line[7:].split(":",2)[0]
+        if client == "0" or "Through" in line:
+            client = "0"
+    else:
+        if client == "0" or line.startswith('\t'):
+            continue
+        port = line.split()[0]
+        port_list.append(client+":"+port)
+for source in port_list:
+    for target in port_list:
+        if source != target:
+            #print("aconnect %s %s" % (source, target))
+            subprocess.call("aconnect %s %s" % (source, target), shell=True)

--- a/lib/menulcd.py
+++ b/lib/menulcd.py
@@ -909,7 +909,7 @@ class MenuLCD:
 
             if choice == "Connect ports":
                 self.render_message("Connecting ports", "", 2000)
-                call("sudo ruby /usr/local/bin/connectall.rb", shell=True)
+                call("sudo ruby %s" % self.midiports.connectall_script, shell=True)
 
             if choice == "Disconnect ports":
                 self.render_message("Disconnecting ports", "", 1000)

--- a/lib/menulcd.py
+++ b/lib/menulcd.py
@@ -909,7 +909,7 @@ class MenuLCD:
 
             if choice == "Connect ports":
                 self.render_message("Connecting ports", "", 2000)
-                call("sudo ruby %s" % self.midiports.connectall_script, shell=True)
+                self.midiports.connectall()
 
             if choice == "Disconnect ports":
                 self.render_message("Disconnecting ports", "", 1000)

--- a/lib/midiports.py
+++ b/lib/midiports.py
@@ -2,10 +2,11 @@ import mido
 
 
 class MidiPorts:
-    def __init__(self, usersettings):
+    def __init__(self, usersettings, connectall_script):
         self.usersettings = usersettings
         self.pending_queue = []
         self.last_activity = 0
+        self.connectall_script = connectall_script
 
         # checking if the input port was previously set by the user
         port = self.usersettings.get_setting_value("input_port")

--- a/lib/midiports.py
+++ b/lib/midiports.py
@@ -1,12 +1,11 @@
 import mido
-
+import subprocess
 
 class MidiPorts:
-    def __init__(self, usersettings, connectall_script):
+    def __init__(self, usersettings):
         self.usersettings = usersettings
         self.pending_queue = []
         self.last_activity = 0
-        self.connectall_script = connectall_script
 
         # checking if the input port was previously set by the user
         port = self.usersettings.get_setting_value("input_port")
@@ -48,6 +47,26 @@ class MidiPorts:
                 print("no play port")
 
         self.portname = "inport"
+
+    def connectall(self):
+        ports = subprocess.check_output(["aconnect", "-i", "-l"], text=True)
+        port_list = []
+        client = "0"
+        for line in str(ports).splitlines():
+            if line.startswith("client "):
+                client = line[7:].split(":",2)[0]
+                if client == "0" or "Through" in line:
+                    client = "0"
+            else:
+                if client == "0" or line.startswith('\t'):
+                    continue
+                port = line.split()[0]
+                port_list.append(client+":"+port)
+
+        for source in port_list:
+            for target in port_list:
+                if source != target:
+                    subprocess.call("sudo aconnect %s %s" % (source, target), shell=True)
 
     def add_instance(self, menu):
         self.menu = menu

--- a/lib/midiports.py
+++ b/lib/midiports.py
@@ -6,6 +6,8 @@ class MidiPorts:
         self.usersettings = usersettings
         self.pending_queue = []
         self.last_activity = 0
+        self.inport = None
+        self.playport = None
 
         # checking if the input port was previously set by the user
         port = self.usersettings.get_setting_value("input_port")
@@ -67,6 +69,8 @@ class MidiPorts:
             for target in port_list:
                 if source != target:
                     subprocess.call("sudo aconnect %s %s" % (source, target), shell=True)
+        # Reconnect the input and playports on a connectall
+        self.reconnect_ports()
 
     def add_instance(self, menu):
         self.menu = menu
@@ -74,9 +78,15 @@ class MidiPorts:
     def change_port(self, port, portname):
         try:
             if port == "inport":
+                if self.inport != None:
+                    self.inport.close()
+                    self.inport = None
                 self.inport = mido.open_input(portname)
                 self.usersettings.change_setting_value("input_port", portname)
             elif port == "playport":
+                if self.playport != None:
+                    self.playport.close()
+                    self.playport = None
                 self.playport = mido.open_output(portname)
                 self.usersettings.change_setting_value("play_port", portname)
             self.menu.render_message("Changing " + port + " to:", portname, 1500)
@@ -85,11 +95,17 @@ class MidiPorts:
 
     def reconnect_ports(self):
         try:
+            if self.inport != None:
+                self.inport.close()
+                self.inport = None
             port = self.usersettings.get_setting_value("input_port")
             self.inport = mido.open_input(port)
         except:
             print("Can't reconnect input port: " + port)
         try:
+            if self.playport != None:
+                self.playport.close()
+                self.playport = None
             port = self.usersettings.get_setting_value("play_port")
             self.playport = mido.open_output(port)
         except:

--- a/visualizer.py
+++ b/visualizer.py
@@ -24,14 +24,20 @@ os.chdir(sys.path[0])
 # Ensure there is only one instance of the script running.
 fh = 0
 
-# make sure connectall.rb file exists and is updated
-if not os.path.exists('/usr/local/bin/connectall.rb'):
-    print("Connectall.rb script not found, creating...")
-    os.mknod('/usr/local/bin/connectall.rb')
+connectall_script = "/usr/local/bin/connectall.rb"
+# Prefer the use of connectall.rb from the same directory
+prog_path = os.path.dirname(os.path.realpath(__file__))
+if os.path.exists(prog_path + "/connectall.rb"):
+    connectall_script = prog_path + "/connectall.rb"
+else :
+    # make sure connectall.rb file exists and is updated
+    if not os.path.exists('/usr/local/bin/connectall.rb'):
+        print("Connectall.rb script not found, creating...")
+        os.mknod('/usr/local/bin/connectall.rb')
 
-if filecmp.cmp('/usr/local/bin/connectall.rb', 'connectall.rb') is not True:
-    print("Connectall.rb script is outdated, updating...")
-    copyfile('connectall.rb', '/usr/local/bin/connectall.rb')
+    if filecmp.cmp('/usr/local/bin/connectall.rb', 'connectall.rb') is not True:
+        print("Connectall.rb script is outdated, updating...")
+        copyfile('connectall.rb', '/usr/local/bin/connectall.rb')
 
 
 def singleton():
@@ -81,7 +87,7 @@ GPIO.setup(KEY3, GPIO.IN, GPIO.PUD_UP)
 GPIO.setup(JPRESS, GPIO.IN, GPIO.PUD_UP)
 
 usersettings = UserSettings()
-midiports = MidiPorts(usersettings)
+midiports = MidiPorts(usersettings, connectall_script)
 ledsettings = LedSettings(usersettings)
 ledstrip = LedStrip(usersettings, ledsettings)
 learning = LearnMIDI(usersettings, ledsettings, midiports, ledstrip)

--- a/visualizer.py
+++ b/visualizer.py
@@ -24,22 +24,6 @@ os.chdir(sys.path[0])
 # Ensure there is only one instance of the script running.
 fh = 0
 
-connectall_script = "/usr/local/bin/connectall.rb"
-# Prefer the use of connectall.rb from the same directory
-prog_path = os.path.dirname(os.path.realpath(__file__))
-if os.path.exists(prog_path + "/connectall.rb"):
-    connectall_script = prog_path + "/connectall.rb"
-else :
-    # make sure connectall.rb file exists and is updated
-    if not os.path.exists('/usr/local/bin/connectall.rb'):
-        print("Connectall.rb script not found, creating...")
-        os.mknod('/usr/local/bin/connectall.rb')
-
-    if filecmp.cmp('/usr/local/bin/connectall.rb', 'connectall.rb') is not True:
-        print("Connectall.rb script is outdated, updating...")
-        copyfile('connectall.rb', '/usr/local/bin/connectall.rb')
-
-
 def singleton():
     global fh
     fh = open(os.path.realpath(__file__), 'r')
@@ -87,7 +71,7 @@ GPIO.setup(KEY3, GPIO.IN, GPIO.PUD_UP)
 GPIO.setup(JPRESS, GPIO.IN, GPIO.PUD_UP)
 
 usersettings = UserSettings()
-midiports = MidiPorts(usersettings, connectall_script)
+midiports = MidiPorts(usersettings)
 ledsettings = LedSettings(usersettings)
 ledstrip = LedStrip(usersettings, ledsettings)
 learning = LearnMIDI(usersettings, ledsettings, midiports, ledstrip)

--- a/webinterface/views_api.py
+++ b/webinterface/views_api.py
@@ -876,7 +876,7 @@ def change_setting():
         call("sudo git pull origin master", shell=True)
 
     if setting_name == "connect_ports":
-        call("sudo ruby /usr/local/bin/connectall.rb", shell=True)
+        call("sudo ruby %s" % webinterface.midiports.connectall_script, shell=True)
         return jsonify(success=True, reload_ports=True)
 
     if setting_name == "disconnect_ports":

--- a/webinterface/views_api.py
+++ b/webinterface/views_api.py
@@ -876,7 +876,7 @@ def change_setting():
         call("sudo git pull origin master", shell=True)
 
     if setting_name == "connect_ports":
-        call("sudo ruby %s" % webinterface.midiports.connectall_script, shell=True)
+        webinterface.midiports.connectall()
         return jsonify(success=True, reload_ports=True)
 
     if setting_name == "disconnect_ports":


### PR DESCRIPTION
Initially the visualizer was changed to support a local copy of connectall.rb, but it turns out it to be cleaner to
add the capability directly into the python code, and it makes it run faster as well.

This also means the ruby dependency can be eliminated.

It was left in as a separate commit in case the separation needs to be added back in the future.