### PR TITLE
Midi race

### DIFF
--- a/lib/functions.py
+++ b/lib/functions.py
@@ -239,9 +239,9 @@ def screensaver(menu, midiports, saving, ledstrip, ledsettings):
                 saving.start_time = time.time()
                 menu.screen_status = 1
                 GPIO.output(24, 1)
-                menu.show()
                 midiports.reconnect_ports()
                 midiports.last_activity = time.time()
+                menu.show()
                 break
         except:
             pass
@@ -250,8 +250,8 @@ def screensaver(menu, midiports, saving, ledstrip, ledsettings):
             saving.start_time = time.time()
             menu.screen_status = 1
             GPIO.output(24, 1)
-            menu.show()
             midiports.reconnect_ports()
+            menu.show()
             break
 
 

--- a/lib/midiports.py
+++ b/lib/midiports.py
@@ -1,5 +1,6 @@
 import mido
 import subprocess
+import time
 
 class MidiPorts:
     def __init__(self, usersettings):
@@ -78,36 +79,39 @@ class MidiPorts:
 
     def change_port(self, port, portname):
         try:
+            destroy_old = None
             if port == "inport":
-                if self.inport != None:
-                    self.inport.close()
-                    self.inport = None
+                destory_old = self.inport
                 self.inport = mido.open_input(portname)
                 self.usersettings.change_setting_value("input_port", portname)
             elif port == "playport":
-                if self.playport != None:
-                    self.playport.close()
-                    self.playport = None
+                destory_old = self.playport
                 self.playport = mido.open_output(portname)
                 self.usersettings.change_setting_value("play_port", portname)
             self.menu.render_message("Changing " + port + " to:", portname, 1500)
+            if destroy_old != None:
+                destory_old.close()
+            self.menu.show()
         except:
             self.menu.render_message("Can't change " + port + " to:", portname, 1500)
+            self.menu.show()
 
     def reconnect_ports(self):
         try:
-            if self.inport != None:
-                self.inport.close()
-                self.inport = None
+            destroy_old = self.inport
             port = self.usersettings.get_setting_value("input_port")
             self.inport = mido.open_input(port)
+            if destroy_old != None:
+                time.sleep(0.002)
+                destroy_old.close()
         except:
             print("Can't reconnect input port: " + port)
         try:
-            if self.playport != None:
-                self.playport.close()
-                self.playport = None
+            destroy_old = self.playport
             port = self.usersettings.get_setting_value("play_port")
             self.playport = mido.open_output(port)
+            if destroy_old != None:
+                time.sleep(0.002)
+                destroy_old.close()
         except:
             print("Can't reconnect play port: " + port)


### PR DESCRIPTION
This rtpmidid series is for two specific problems:

1) When switching the playback device or input device, 
     the device endpoints must be destroyed or it ends up creating loops.

     After this commit the behavior changes slightly.  Previously
     the piano and another source could both be inputs to the light bar
     at the same time if you selected one after the other in the menu
     because a new end point was created each time.  But this also
     caused the problem described above.   The light bar should only
     be connected to one source at a time.

2) The inport and playback port are not protected by a mutex, which
    means some care needs to be taken to wait for the main thread to
    not be using either resource when performing connect operations
    by the web server thread.