### PR TITLE
Improve Wi-Fi setup instructions

### DIFF
--- a/Docs/manual_installation.md
+++ b/Docs/manual_installation.md
@@ -1,9 +1,8 @@
 
 Install [Raspberry Pi OS Lite](https://www.raspberrypi.org/software/) on your SD card.
 
-If you are not able to connect your monitor, mouse and keyboard to RPi you can connect to it using SSH. Here you can find full tutorial: [Raspberry Pi Setup Without a Monitor, Keyboard or a Mouse](https://www.terminalbytes.com/raspberry-pi-without-monitor-keyboard/ "Raspberry Pi Setup Without a Monitor, Keyboard or a Mouse")
+If you are not able to connect your monitor, mouse and keyboard to RPi you can connect to it using SSH over [Wi-Fi](https://github.com/onlaj/Piano-LED-Visualizer/blob/master/Docs/wifi_setup.md)
 
-*Note: replace `“` with `"` when editing `wpa_supplicant.conf` file.*
 
  
 ### 1. **Updating OS** 

--- a/Docs/wifi_setup.md
+++ b/Docs/wifi_setup.md
@@ -1,0 +1,21 @@
+### **Wi-Fi setup** (Optional)
+  1. In the boot partition of the card you flashed, create a file named `wpa_supplicant.conf` and add the following lines, replacing the ssid and passkey with your own:
+```
+country=IE 
+ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev 
+update_config=1 
+network={ 
+scan_ssid=1 
+ssid="wifi-network-name"        # Replace with your Wi-Fi name
+psk="wifi-network-password"     # Replace with your Wi-Fi password
+key_mgmt=WPA-PSK 
+}
+```
+  2. Create another file named `ssh` in the same folder, leave it empty and with no extension. This will allow you to remotely access the RPi's command line. This is not required, but it might make setup easier.
+  3. Eject the card and put it in the Raspberry Pi. The pi can take a moment to boot up, so give it a few minutes. There are a few ways you can find the ip of the RPi: 
+   
+     - If you have an lcd screen, go to *`Other Settings`* > *`Screensaver`* > *`Content`*, and enable `Local IP`. From there, go to *`Other Settings`* and open `System Info`. If the Rpi is connected, it will display the ip
+     - Run the command `ping raspberrypi.local`. This might not work, but if it does it should output the ip address.
+     - Run the command `nmap 192.168.0.1/24 -p 80`. The RPi should have an open address. Note that `192.168.0.1/24` is the subnet, and might be different depending on the network.
+     - Use an app like [Fing](https://play.google.com/store/apps/details?id=com.overlook.android.fing&hl=en_IN) to find the ip.
+  4. If you need to ssh into the pi to run commands, run `ssh pi@[the-ip-address]` with the password `raspberry`

--- a/README.md
+++ b/README.md
@@ -42,14 +42,13 @@ There are two ways, you can use preconfigured system image or install everything
 - Unzip the file.
 - Use program like [Win32 Disk Imager](https://sourceforge.net/projects/win32diskimager/) or [Etcher](https://www.balena.io/etcher/) to save system image to your SD card (4GB is a minimum).
 
-If you don't need to connect your RPi to Wi-Fi you can eject SD card from your PC and put it in Raspberry Pi. After 3-8 minutes *(depending on how fast your SD card is)* you should see Visualizer menu on RPi screen.
+If you don't need to connect your RPi to Wi-Fi you can eject SD card from your PC and put it in Raspberry Pi. After 3-8 minutes *(depending on how fast your SD card is)* you should see Visualizer menu on RPi screen.  
 
-If you want to make your RPi autoconnect to Wi-Fi you need to follow [this guide](https://www.terminalbytes.com/raspberry-pi-without-monitor-keyboard/) *(starting from step 3)*
+### 2. **Wi-Fi setup** (Optional)
+[Wi-Fi setup](https://github.com/onlaj/Piano-LED-Visualizer/blob/master/Docs/wifi_setup.md) is optional, but will be needed if you wish to use the [web interface](https://github.com/onlaj/Piano-LED-Visualizer#web-interface)
 
-*Note: replace `“` with `"` when editing `wpa_supplicant.conf` file.*
-
-### 2. **Manual installation**
-[Instruction](https://github.com/onlaj/Piano-LED-Visualizer/blob/master/Docs/manual_installation.md)
+### 3. **Manual installation**
+[Instructions](https://github.com/onlaj/Piano-LED-Visualizer/blob/master/Docs/manual_installation.md)
 
 ## Connecting LED Strip to Raspberry Pi and enabling SPI
 There is no point to reinvent the wheel again, here is a nice [tutorial](https://tutorials-raspberrypi.com/connect-control-raspberry-pi-ws2812-rgb-led-strips/) *(do only the hardware part)*


### PR DESCRIPTION
The previous instructions linked in the README had hard-to-notice typos which prevented the visualizer from connecting to Wi-Fi. There are also a few ways of finding the IP specific to the visualizer. 