### PR TITLE
Support for 60LEDS/m

### DIFF
--- a/lib/functions.py
+++ b/lib/functions.py
@@ -254,12 +254,15 @@ def get_note_position(note, ledstrip, ledsettings):
             break
     note_offset -= ledstrip.shift
 
+    
     if (ledsettings.low_density == 1):
-        density = 1
+        leds_per_meter = 60
     else:
-        density = 2
+        leds_per_meter = 144
 
-    note_pos_raw = density * (note - 20) - note_offset
+    density = leds_per_meter/72
+
+    note_pos_raw = int(density * (note - 20) - note_offset)
     if ledstrip.reverse:
         return max(0, ledstrip.led_number - note_pos_raw)
     else:

--- a/webinterface/templates/ledsettings.html
+++ b/webinterface/templates/ledsettings.html
@@ -165,7 +165,7 @@ grid sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4
                         <div class="uppercase">Low density</div>
                         <div class='has-tooltip'>
                         <span class='inline-block tooltip rounded shadow-lg p-1 bg-gray-100 dark:bg-gray-600 text-gray-600 dark:text-gray-400 -mt-8'>
-                            For LED strips with 72 or less LEDs/m
+                            For LED strips with 60 LEDs/m
                         </span>
                             <svg xmlns="http://www.w3.org/2000/svg" class="ml-1 h-4 w-4" fill="none"
                                  viewBox="0 0 24 24"


### PR DESCRIPTION
By default, the "low density" option is configured only for LED strips of 72LEDS/m. Because addressable LED strips of the 72LED/m kind are very uncommon compared to the 60LED/m kind (like the WS2812), I suggest that we change the low density option to work with 60LED/m strips instead.