### PR TITLE
Add ledstrip fps stats

### DIFF
--- a/config/default_settings.xml
+++ b/config/default_settings.xml
@@ -112,5 +112,5 @@
 	<is_loop_active>1</is_loop_active>
     <midi_logging>1</midi_logging>
 
-
+	<fps_limiter>0</fps_limiter>
 </settings>

--- a/lib/ledsettings.py
+++ b/lib/ledsettings.py
@@ -90,6 +90,8 @@ class LedSettings:
 
         self.sequence_number = 0
 
+        self.fps_limiter = int(usersettings.get_setting_value("fps_limiter"))
+
         # if self.mode == "Disabled" and self.color_mode != "disabled":
         #    usersettings.change_setting_value("color_mode", "disabled")
 

--- a/lib/ledstrip.py
+++ b/lib/ledstrip.py
@@ -18,6 +18,8 @@ class LedStrip:
         self.keylist_status = [0] * self.led_number
         self.keylist_color = [0] * self.led_number
 
+        self.current_fps = 0
+
         # LED strip configuration:
         self.LED_COUNT = int(self.led_number)  # Number of LED pixels.
         self.LED_PIN = 18  # GPIO pin connected to the pixels (18 uses PWM!).

--- a/lib/menulcd.py
+++ b/lib/menulcd.py
@@ -73,7 +73,7 @@ class MenuLCD:
 
         self.led_animation = usersettings.get_setting_value("led_animation")
 
-        self.screen_on = usersettings.get_setting_value("screen_on")
+        self.screen_on = int(usersettings.get_setting_value("screen_on"))
 
         self.screen_status = 1
 

--- a/webinterface/static/index.js
+++ b/webinterface/static/index.js
@@ -153,13 +153,20 @@ function get_homepage_data_loop() {
             document.getElementById("memory_usage").innerHTML =
                 formatBytes(response_pc_stats.memory_usage_used, 2, false) + "/" +
                 formatBytes(response_pc_stats.memory_usage_total);
-            document.getElementById("cpu_temp").innerHTML = response_pc_stats.cpu_temp + "°C";
+            document.getElementById("cpu_temp").innerHTML = response_pc_stats.cpu_temp;
             document.getElementById("card_usage").innerHTML =
                 formatBytes(response_pc_stats.card_space_used, 2, false) + "/" +
                 formatBytes(response_pc_stats.card_space_total);
             document.getElementById("card_usage_percent").innerHTML = response_pc_stats.card_space_percent + "%";
             animateValue(document.getElementById("download_number"), last_download, download, refresh_rate * 500, true);
             animateValue(document.getElementById("upload_number"), last_upload, upload, refresh_rate * 500, true);
+            document.getElementById("led_fps").innerHTML = response_pc_stats.led_fps;
+            document.getElementById("cpu_count").innerHTML = response_pc_stats.cpu_count;
+            document.getElementById("cpu_pid").innerHTML = response_pc_stats.cpu_pid;
+            document.getElementById("cpu_freq").innerHTML = response_pc_stats.cpu_freq;
+            document.getElementById("memory_pid").innerHTML =
+                formatBytes(response_pc_stats.memory_pid, 2, false);
+
             document.getElementById("cover_state").innerHTML = response_pc_stats.cover_state;
 
             download_start = response_pc_stats.download;

--- a/webinterface/templates/home.html
+++ b/webinterface/templates/home.html
@@ -36,8 +36,13 @@
                               d="M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0
                             002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2zM9 9h6v6H9V9z"/>
                     </svg>
-                    <div class="bg-red-500 rounded-full h-6 px-2 flex justify-items-center text-white font-semibold text-sm">
-                        <span id="cpu_temp" class="flex items-center">°C</span>
+                    <div class="h-6 flex justify-items-center text-white font-semibold text-sm">
+                        <div class="bg-blue-500 rounded-full px-2 flex">
+                            <span class="flex items-center"><span id="cpu_freq"></span> Mhz</span>
+                        </div>
+                        <div class="bg-red-500 rounded-full px-2 flex">
+                            <span class="flex items-center"><span id="cpu_temp">--</span>°C</span>
+                        </div>
                     </div>
                 </div>
                 <div class="ml-2 w-full flex-1">
@@ -45,7 +50,8 @@
                         <div id="cpu_usage" class="mt-3 text-3xl font-bold leading-8"><span id='cpu_number'></span>%
                         </div>
 
-                        <div class="mt-1 text-base text-gray-600 dark:text-gray-400">CPU Usage</div>
+                        <div class="mt-1 text-base text-gray-600 dark:text-gray-400">System CPU Usage (<span id="cpu_count"></span> CPU)
+                        </div>
                     </div>
                 </div>
             </div>
@@ -126,6 +132,50 @@
                         </div>
 
                         <div class="mt-1 text-base text-gray-600 dark:text-gray-400">Bandwidth Usage</div>
+                    </div>
+                </div>
+            </div>
+        </a>
+        <a class="transform  hover:scale-105 transition duration-300 shadow-xl rounded-lg col-span-12
+        sm:col-span-6 xl:col-span-3 intro-y bg-gray-200 dark:bg-gray-700" href="#/">
+            <div class="p-5">
+                <div class="flex justify-between">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z" />
+                    </svg>
+                </div>
+                <div class="ml-2 w-full flex-1">
+                    <div>
+                        <div id="led_fps_div" class="mt-3 text-3xl font-bold leading-8"><span id='led_fps'>--.--</span>
+                        </div>
+
+                        <div class="mt-1 text-base text-gray-600 dark:text-gray-400">LED FPS</div>
+                    </div>
+                </div>
+            </div>
+        </a>
+        <a class="transform  hover:scale-105 transition duration-300 shadow-xl rounded-lg col-span-12
+        sm:col-span-6 xl:col-span-3 intro-y bg-gray-200 dark:bg-gray-700" href="#/">
+            <div class="p-5">
+                <div class="flex justify-between">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none"
+                         viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                              d="M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0
+                            002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2zM9 9h6v6H9V9z"/>
+                    </svg>
+                    <div class="h-6 flex justify-items-center text-white font-semibold text-sm">
+                        <div class="bg-blue-500 rounded-full px-2 flex">
+                            <span class="flex items-center"><span id="memory_pid"></span> MB</span>
+                        </div>
+                    </div>
+                </div>
+                <div class="ml-2 w-full flex-1">
+                    <div>
+                        <div id="cpu_pid_div" class="mt-3 text-3xl font-bold leading-8"><span id='cpu_pid'>--</span>%
+                        </div>
+
+                        <div class="mt-1 text-base text-gray-600 dark:text-gray-400">Process CPU Usage</div>
                     </div>
                 </div>
             </div>

--- a/webinterface/views_api.py
+++ b/webinterface/views_api.py
@@ -22,6 +22,8 @@ SENSECOVER = 12
 GPIO.setmode(GPIO.BCM)
 GPIO.setup(SENSECOVER, GPIO.IN, GPIO.PUD_UP)
 
+pid = psutil.Process(os.getpid())
+
 
 @webinterface.route('/api/start_animation', methods=['GET'])
 def start_animation():
@@ -81,6 +83,8 @@ def start_animation():
 
 @webinterface.route('/api/get_homepage_data')
 def get_homepage_data():
+    global pid
+
     try:
         temp = find_between(str(psutil.sensors_temperatures()["cpu_thermal"]), "current=", ",")
     except:
@@ -97,16 +101,21 @@ def get_homepage_data():
 
     homepage_data = {
         'cpu_usage': psutil.cpu_percent(interval=0.1),
+        'cpu_count': psutil.cpu_count(),
+        'cpu_pid': pid.cpu_percent(),
+        'cpu_freq': psutil.cpu_freq().current,
         'memory_usage_percent': psutil.virtual_memory()[2],
         'memory_usage_total': psutil.virtual_memory()[0],
         'memory_usage_used': psutil.virtual_memory()[3],
+        'memory_pid': pid.memory_full_info().rss,
         'cpu_temp': temp,
         'upload': upload,
         'download': download,
         'card_space_used': card_space.used,
         'card_space_total': card_space.total,
         'card_space_percent': card_space.percent,
-        'cover_state': 'Opened' if cover_opened else 'Closed'
+        'cover_state': 'Opened' if cover_opened else 'Closed',
+        'led_fps': round(webinterface.ledstrip.current_fps, 2),
     }
     return jsonify(homepage_data)
 


### PR DESCRIPTION
Add fps stats (and a few others) to website homepage.
Also an experimental fps limiter to save cpu.

Some stats on my Rasp Pi 3B:
~84 fps with menulcd screen off (I don't have a menulcd); ~50% process cpu.  (Time spent in ws821x library not using cpu.)
~40 fps with menulcd screen on, but it isn't so bad since again isn't burning cpu, and seems to jump back to 84 when piano is played.
