### PR TITLE
Add accurate midi timestamps

### DIFF
--- a/lib/color_mode.py
+++ b/lib/color_mode.py
@@ -40,7 +40,7 @@ class ColorMode(object):
         """Called whenever settings change"""
         pass
 
-    def NoteOn(self, midi_event, midi_state, note_position):
+    def NoteOn(self, midi_event, midi_time, midi_state, note_position):
         """Primary high-level function for ColorMode
 
         Called on midi note-on
@@ -74,7 +74,7 @@ class SingleColor(ColorMode):
         self.green = ledsettings.get_color("Green")
         self.blue = ledsettings.get_color("Blue")
 
-    def NoteOn(self, midi_event: mido.Message, midi_state, note_position):
+    def NoteOn(self, midi_event: mido.Message, midi_time, midi_state, note_position):
         return (self.red, self.green, self.blue)
 
 
@@ -85,7 +85,7 @@ class Multicolor(ColorMode):
         self.multicolor_index = 0
         self.multicolor_iteration = ledsettings.multicolor_iteration
 
-    def NoteOn(self, midi_event: mido.Message, midi_state, note_position):
+    def NoteOn(self, midi_event: mido.Message, midi_time, midi_state, note_position):
             chosen_color = self.get_random_multicolor_in_range(midi_event.note)
             return chosen_color
 
@@ -141,7 +141,7 @@ class Rainbow(ColorMode):
         self.timeshift = int(ledsettings.rainbow_timeshift)
         self.timeshift_start = time.time()
 
-    def NoteOn(self, midi_event: mido.Message, midi_state, note_position):
+    def NoteOn(self, midi_event: mido.Message, midi_time, midi_state, note_position):
         shift = (time.time() - self.timeshift_start) * self.timeshift
         return self.calculate_rainbow_colors(note_position, shift)
 
@@ -165,7 +165,7 @@ class SpeedColor(ColorMode):
         self.speed_period_in_seconds = ledsettings.speed_period_in_seconds
         self.speed_max_notes = ledsettings.speed_max_notes
 
-    def NoteOn(self, midi_event: mido.Message, midi_state, note_position):
+    def NoteOn(self, midi_event: mido.Message, midi_time, midi_state, note_position):
         current_time = time.time()
         self.notes_in_last_period.append(current_time)
         return self.speed_get_colors()
@@ -204,7 +204,7 @@ class Gradient(ColorMode):
                              "green": int(ledsettings.usersettings.get_setting_value("gradient_end_green")),
                              "blue": int(ledsettings.usersettings.get_setting_value("gradient_end_blue"))}
 
-    def NoteOn(self, midi_event: mido.Message, midi_state, note_position):
+    def NoteOn(self, midi_event: mido.Message, midi_time, midi_state, note_position):
         return self.gradient_get_colors(note_position)
 
     def gradient_get_colors(self, position):
@@ -224,7 +224,7 @@ class ScaleColoring(ColorMode):
         self.key_in_scale = ledsettings.key_in_scale
         self.key_not_in_scale = ledsettings.key_not_in_scale
 
-    def NoteOn(self, midi_event: mido.Message, midi_state, note_position):
+    def NoteOn(self, midi_event: mido.Message, midi_time, midi_state, note_position):
         scale_colors = get_scale_color(self.scale_key, midi_event.note, self.key_in_scale, self.key_not_in_scale)
         return scale_colors
 
@@ -235,7 +235,7 @@ class VelocityRainbow(ColorMode):
         self.scale = int(ledsettings.velocityrainbow_scale)
         self.curve = int(ledsettings.velocityrainbow_curve)
 
-    def NoteOn(self, midi_event: mido.Message, midi_state, note_position=None):
+    def NoteOn(self, midi_event: mido.Message, midi_time, midi_state, note_position):
         x = int(((255 * powercurve(midi_event.velocity / 127, self.curve / 100)
                     * (self.scale / 100) % 256) + self.offset) % 256)
         x2 = colorsys.hsv_to_rgb(x / 255, 1, (midi_event.velocity / 127) * 0.3 + 0.7)

--- a/lib/functions.py
+++ b/lib/functions.py
@@ -59,7 +59,7 @@ def shift(lst, num_shifts):
 
 
 def play_midi(song_path, midiports, saving, menu, ledsettings, ledstrip):
-    midiports.midifile_queue.append((mido.Message('note_on'), time.time()))
+    midiports.midifile_queue.append((mido.Message('note_on'), time.perf_counter()))
 
     if song_path in saving.is_playing_midi.keys():
         menu.render_message(song_path, "Already playing", 2000)
@@ -81,10 +81,10 @@ def play_midi(song_path, midiports, saving, menu, ledsettings, ledstrip):
         for message in mid:
             if song_path in saving.is_playing_midi.keys():
                 if not t0:
-                    t0 = time.time()
+                    t0 = time.perf_counter()
 
                 total_delay += message.time
-                current_time = (time.time() - t0) + message.time
+                current_time = (time.perf_counter() - t0) + message.time
                 drift = total_delay - current_time
 
                 if drift < 0:
@@ -94,7 +94,7 @@ def play_midi(song_path, midiports, saving, menu, ledsettings, ledstrip):
                 if delay < 0:
                     delay = 0
 
-                msg_timestamp = time.time() + delay
+                msg_timestamp = time.perf_counter() + delay
                 if delay > 0:
                     time.sleep(delay)
                 if not message.is_meta:
@@ -106,8 +106,8 @@ def play_midi(song_path, midiports, saving, menu, ledsettings, ledstrip):
                 strip = ledstrip.strip
                 fastColorWipe(strip, True, ledsettings)
                 break
-        print('play time: {:.2f} s (expected {:.2f})'.format(time.time() - t0, total_delay))
-        # print('play time: {:.2f} s (expected {:.2f})'.format(time.time() - t0, length))
+        print('play time: {:.2f} s (expected {:.2f})'.format(time.perf_counter() - t0, total_delay))
+        # print('play time: {:.2f} s (expected {:.2f})'.format(time.perf_counter() - t0, length))
         # saving.is_playing_midi = False
     except FileNotFoundError:
         menu.render_message(song_path, "File not found", 2000)
@@ -202,14 +202,14 @@ def screensaver(menu, midiports, saving, ledstrip, ledsettings):
     while True:
         manage_idle_animation(ledstrip, ledsettings, menu)
 
-        if (time.time() - saving.start_time) > 3600 and delay < 0.5 and menu.screensaver_is_running is False:
+        if (time.perf_counter() - saving.start_time) > 3600 and delay < 0.5 and menu.screensaver_is_running is False:
             delay = 0.9
             interval = 5 / float(delay)
             cpu_history = [None] * int(interval)
             cpu_average = 0
             i = 0
 
-        if int(menu.screen_off_delay) > 0 and ((time.time() - saving.start_time) > (int(menu.screen_off_delay) * 60)):
+        if int(menu.screen_off_delay) > 0 and ((time.perf_counter() - saving.start_time) > (int(menu.screen_off_delay) * 60)):
             menu.screen_status = 0
             GPIO.output(24, 0)
 
@@ -277,7 +277,7 @@ def screensaver(menu, midiports, saving, ledstrip, ledsettings):
         try:
             if str(midiports.inport.poll()) != "None":
                 menu.screensaver_is_running = False
-                saving.start_time = time.time()
+                saving.start_time = time.perf_counter()
                 menu.screen_status = 1
                 GPIO.output(24, 1)
                 midiports.reconnect_ports()
@@ -288,7 +288,7 @@ def screensaver(menu, midiports, saving, ledstrip, ledsettings):
             pass
         if GPIO.input(KEY2) == 0:
             menu.screensaver_is_running = False
-            saving.start_time = time.time()
+            saving.start_time = time.perf_counter()
             menu.screen_status = 1
             GPIO.output(24, 1)
             midiports.reconnect_ports()

--- a/lib/functions.py
+++ b/lib/functions.py
@@ -59,7 +59,7 @@ def shift(lst, num_shifts):
 
 
 def play_midi(song_path, midiports, saving, menu, ledsettings, ledstrip):
-    midiports.pending_queue.append(mido.Message('note_on'))
+    midiports.midifile_queue.append((mido.Message('note_on'), time.time()))
 
     if song_path in saving.is_playing_midi.keys():
         menu.render_message(song_path, "Already playing", 2000)
@@ -94,14 +94,15 @@ def play_midi(song_path, midiports, saving, menu, ledsettings, ledstrip):
                 if delay < 0:
                     delay = 0
 
+                msg_timestamp = time.time() + delay
                 if delay > 0:
                     time.sleep(delay)
                 if not message.is_meta:
                     midiports.playport.send(message)
-                    midiports.pending_queue.append(message.copy(time=0))
+                    midiports.midifile_queue.append((message.copy(time=0), msg_timestamp))
 
             else:
-                midiports.pending_queue.clear()
+                midiports.midifile_queue.clear()
                 strip = ledstrip.strip
                 fastColorWipe(strip, True, ledsettings)
                 break

--- a/lib/learnmidi.py
+++ b/lib/learnmidi.py
@@ -350,7 +350,11 @@ class LearnMIDI:
                             wrong_notes = []
                             self.predict_future_notes(absolute_idx, end_idx, notes_to_press)
                             while not set(notes_to_press).issubset(notes_pressed) and self.is_started_midi:
-                                for msg_in in self.midiports.inport.iter_pending():
+                                while self.midiports.midi_queue:
+                                    msg_in, msg_timestamp = self.midiports.midi_queue.popleft()
+                                    if msg_in.type not in ("note_on", "note_off"):
+                                        continue
+
                                     note = int(find_between(str(msg_in), "note=", " "))
 
                                     if "note_off" in str(msg_in):

--- a/lib/ledstrip.py
+++ b/lib/ledstrip.py
@@ -36,6 +36,8 @@ class LedStrip:
                                        self.LED_BRIGHTNESS, self.LED_CHANNEL, ws.WS2811_STRIP_GRB)
         # Intialize the library (must be called once before other functions).
         self.strip.begin()
+        if "releaseGIL" in dir(self.strip):
+            self.strip.releaseGIL()
         self.change_gamma(self.led_gamma)
 
     def change_gamma(self, value):

--- a/lib/midiports.py
+++ b/lib/midiports.py
@@ -104,4 +104,4 @@ class MidiPorts:
             print("Can't reconnect play port: " + port)
 
     def msg_callback(self, msg):
-        self.midi_queue.append((msg, time.time()))
+        self.midi_queue.append((msg, time.perf_counter()))

--- a/lib/savemidi.py
+++ b/lib/savemidi.py
@@ -13,7 +13,7 @@ class SaveMIDI:
         self.menu = None
         self.is_recording = False
         self.is_playing_midi = {}
-        self.start_time = time.time()
+        self.start_time = time.perf_counter()
 
     def add_instance(self, menu):
         self.menu = menu
@@ -75,4 +75,4 @@ class SaveMIDI:
         self.menu.render_message("File saved", filename + ".mid", 1500)
 
     def restart_time(self):
-        self.start_time = time.time()
+        self.start_time = time.perf_counter()

--- a/lib/savemidi.py
+++ b/lib/savemidi.py
@@ -54,12 +54,9 @@ class SaveMIDI:
             self.mid = MidiFile(None, None, 0, 20000)  # 20000 is a ticks_per_beat value
             self.track = MidiTrack()
             self.mid.tracks.append(self.track)
-            previous_message_time = None
+            previous_message_time = self.first_note_time
             for message in multicolor_track:
-                if previous_message_time is not None:
-                    time_delay = message[1] - previous_message_time
-                else:
-                    time_delay = 0
+                time_delay = message[1] - previous_message_time
                 previous_message_time = message[1]
 
                 if message[0] == "note":

--- a/visualizer.py
+++ b/visualizer.py
@@ -413,7 +413,7 @@ while True:
             if note_position >= ledstrip.led_number or note_position < 0:
                 continue
 
-            color = color_mode.NoteOn(msg, None, note_position)
+            color = color_mode.NoteOn(msg, msg_timestamp, None, note_position)
             if color is not None:
                 red, green, blue = color
             else:

--- a/visualizer.py
+++ b/visualizer.py
@@ -192,9 +192,9 @@ if args.webinterface != "false":
 manage_hotspot(hotspot, usersettings, midiports, True)
 
 # Frame rate counters
-event_loop_stamp = time.time()
+event_loop_stamp = time.perf_counter()
 frame_count = 0
-frame_avg_stamp = time.time()
+frame_avg_stamp = time.perf_counter()
 
 # Main event loop
 
@@ -204,7 +204,7 @@ while True:
         if (time.time() - midiports.last_activity) > (int(menu.screensaver_delay) * 60):
             screensaver(menu, midiports, saving, ledstrip, ledsettings)
     try:
-        elapsed_time = time.time() - saving.start_time
+        elapsed_time = time.perf_counter() - saving.start_time
     except Exception as e:
         # Handle any other unexpected exceptions here
         print(f"Unexpected exception occurred: {e}")
@@ -501,11 +501,12 @@ while True:
 
     # Frame time calculations
 
-    # time taken for the last interation of the main event loop
-    event_loop_time = time.time() - event_loop_stamp
+    # time taken for the last iteration of the main event loop
+    event_loop_time = time.perf_counter() - event_loop_stamp
+    event_loop_stamp = time.perf_counter()
 
     frame_count += 1
-    frame_seconds = time.time() - frame_avg_stamp
+    frame_seconds = time.perf_counter() - frame_avg_stamp
 
     # calculate fps average over 2 seconds
     if frame_seconds >= 2:
@@ -513,7 +514,5 @@ while True:
         ledstrip.current_fps = fps
 
         # reset counters
-        frame_avg_stamp = time.time()
+        frame_avg_stamp = time.perf_counter()
         frame_count = 0
-
-    event_loop_stamp = time.time()


### PR DESCRIPTION
Add midi timestamps via Mido callback.

I originally wrote this in July/Aug, (and re-wrote now due to the many upstream changes).  But never created a pull request because it's all for naught if PixelStrip's render holds the GIL for the duration.  On my Pi/ledstrip setup, it's held for a good 11ms, which means any two notes could be recorded off by up to 22ms, enough to be noticeable.

This time I decided to patch rpi-ws281x to prevent GIL locking during render:
https://github.com/rpi-ws281x/rpi-ws281x-python/pull/102
This should make the project much more thread-friendly regardless of the timestamps.

There's also discussion on Mido to use the backend rtmidi's delta timestamps:
https://github.com/orgs/mido/discussions/485
But I'm not sure if those deltas would also be affected by PixelStrip's render lock.

The midi parsing in visualizer.py was also cleaned up a bit.
