### PR TITLE
UserSettings: Supported nested structure, dict conversion, fast lookups

### DIFF
--- a/lib/usersettings.py
+++ b/lib/usersettings.py
@@ -1,62 +1,158 @@
 from xml.etree import ElementTree as ET
 import time
+from functools import reduce
 
 
 class UserSettings:
-    def __init__(self):
+    def __init__(self, config="config/settings.xml", default_config="config/default_settings.xml"):
+        self.cache = {}
+
+        self.CONFIG_FILE = config
+        self.DEFAULT_CONFIG_FILE = default_config
         self.pending_changes = False
         self.last_save = 0
+
         try:
-            self.tree = ET.parse("config/settings.xml")
+            self.tree = ET.parse(self.CONFIG_FILE)
             self.root = self.tree.getroot()
+            self.xml_to_dict(self.cache, self.root)
         except:
             print("Can't load settings file, restoring defaults")
             self.reset_to_default()
 
         self.pending_reset = False
 
-        self.default_tree = ET.parse("config/default_settings.xml")
-        self.default_root = self.default_tree.getroot()
+        self.copy_missing()
+        if self.pending_changes:
+            self.save_changes()
 
-    def get_setting_value(self, name):
-        elem = self.root.find(name)
-        if elem is None:
-            elem = self.default_root.find(name)
 
-        if elem is None:
+    # get setting
+
+    def __getitem__(self, key):
+        if isinstance(key, str):
+            return self.cache[key]
+        elif hasattr(key, '__iter__'):
+            # deep get
+            return reduce(dict.__getitem__, key, self.cache)
+
+    def get(self, key):
+        try:
+            return self.__getitem__(key)
+        except:
             return None
 
-        return elem.text
+    def get_setting_value(self, name):
+        return self.get(name)
+
+    def get_copy(self):
+        return self.cache.copy()
+
+
+    # set setting
+
+    def __setitem__(self, key, value):
+        val = str(value)
+        self._xml_set(key, val)
+
+        if isinstance(key, str):
+            self.cache[key] = val
+        elif hasattr(key, '__iter__'):
+            d = reduce(dict.__getitem__, key[:-1], self.cache)
+            d[key[-1]] = val
+
+    def set(self, key, value):
+        self.__setitem__(key, value)
 
     def change_setting_value(self, name, value):
-        elem = self.root.find(str(name))
+        self.set(name, value)
+
+
+
+    def get_cms(self, color_mode, key=None):
+        if key is None:
+            return self.get(("color_mode_settings", color_mode))
+
+        return self.get(("color_mode_settings", color_mode, key))
+
+    def set_cms(self, color_mode, key, value):
+        return self.set(("color_mode_settings", color_mode, key), value)
+
+
+    def _xml_set(self, key, value):
+        if isinstance(key, str):
+            xpath = key
+        elif hasattr(key, '__iter__'):
+            xpath = '/'.join(key)
+
+        elem = self.root.find("./" + xpath)
         if elem is None:
-            elem = ET.Element(str(name))
-            elem.text = str(value)
-            self.root.append(elem)
-            # Appended item will have no whitespace formatting
+            raise Exception("XML path not found: " + xpath) 
 
-            # ElementTree.indent only available in Python 3.9+
-            # This will reformat the whole file and remove extraneous line-breaks, so leaving commented out
-            # if "indent" in dir(ET):
-            #    ET.indent(self.root)
-        else:
-            elem.text = str(value)
-
+        elem.text = str(value)
         self.pending_changes = True
 
     def save_changes(self):
         if self.pending_changes:
             self.pending_changes = False
 
-            self.tree.write("config/settings.xml")
-            self.tree = ET.parse("config/settings.xml")
+            self.tree.write(self.CONFIG_FILE)
+            self.tree = ET.parse(self.CONFIG_FILE)
             self.root = self.tree.getroot()
+            self.xml_to_dict(self.cache, self.root)
             self.last_save = time.time()
 
     def reset_to_default(self):
-        self.tree = ET.parse("config/default_settings.xml")
-        self.tree.write("config/settings.xml")
+        self.tree = ET.parse(self.DEFAULT_CONFIG_FILE)
+        self.tree.write(self.CONFIG_FILE)
         self.root = self.tree.getroot()
+        self.xml_to_dict(self.cache, self.root)
         self.pending_reset = True
         self.last_save = time.time()
+
+    def xml_to_dict(self, dict, node):
+        """Recursively convert xml node into dict
+        Assumes xml is simple <tag>text</tag> format, attributes ignored
+        """
+        for elem in node:
+            if len(elem) == 0:
+                # No subelements, get text as value
+                dict[elem.tag] = elem.text
+            else:
+                dict[elem.tag] = {}
+                self.xml_to_dict(dict[elem.tag], elem)
+
+    def copy_missing(self):
+        path = []
+        for event, def_elem in ET.iterparse(self.DEFAULT_CONFIG_FILE, events=("start", "end")):
+            if event == 'start':
+                path.append(def_elem.tag)
+
+                # iterparse makes path[0] the root "settings"; skip root
+                if len(path[1:]) == 0:
+                    continue
+
+                # Find element in settings.xml
+                findstr = './' + '/'.join(path[1:])
+                elem = self.root.find(findstr)
+
+                # If element is missing, copy it to the correct location
+                if elem is None:
+                    #ET.dump(def_elem)
+
+                    # [1: - ignore 'settings' root element
+                    # :-1] - get parent; do not include current (last) element
+                    if len(path[1:-1]) == 0:
+                        parent_elem = self.root
+                    else:
+                        parent_find = './' + '/'.join(path[1:-1])
+                        parent_elem = self.root.find(parent_find)
+                    
+                    parent_elem.insert(0, def_elem)     # better indentation preservation when inserting at top, vs append
+                    self.pending_changes = True
+
+            elif event == 'end':
+                path.pop()
+
+        if self.pending_changes:
+            self.xml_to_dict(self.cache, self.root)

--- a/tests/config-test/default-test1.xml
+++ b/tests/config-test/default-test1.xml
@@ -1,0 +1,26 @@
+<settings>
+    <screen_on>1</screen_on>
+    <brightness_percent>50</brightness_percent>
+    <background_color>BLACK</background_color>
+    <text_color>WHITE</text_color>
+
+    <mode>Normal</mode>
+    <red>255</red>
+    <green>255</green>
+    <blue>255</blue>
+
+    <fadingspeed>1000</fadingspeed>
+    <color_mode>VelocityRainbow</color_mode>
+
+    <color_mode_settings>
+        <VelocityRainbow>
+            <offset>210</offset>
+            <scale>120</scale>
+            <curve>0</curve>
+        </VelocityRainbow>
+    </color_mode_settings>
+
+    <note_offsets>[[92, 2], [55, 1]]</note_offsets>
+    
+
+</settings>

--- a/tests/config-test/default-test2.xml
+++ b/tests/config-test/default-test2.xml
@@ -1,0 +1,35 @@
+<settings>
+    <missing>miss1</missing>
+    <missing_nest>
+        <sub>sub</sub>
+    </missing_nest>
+    
+    <screen_on>1</screen_on>
+    <brightness_percent>50</brightness_percent>
+    <background_color>BLACK</background_color>
+    <text_color>WHITE</text_color>
+
+    <mode>Normal</mode>
+    <red>255</red>
+    <green>255</green>
+    <blue>255</blue>
+
+    <fadingspeed>1000</fadingspeed>
+    <color_mode>VelocityRainbow</color_mode>
+
+    <color_mode_settings>
+        <VelocityRainbow>
+            <offset>210</offset>
+            <scale>120</scale>
+            <curve>0</curve>
+            <missing>miss2</missing>
+        </VelocityRainbow>
+        <missing_color_mode>
+            <param>1</param>
+        </missing_color_mode>
+    </color_mode_settings>
+
+    <note_offsets>[[92, 2], [55, 1]]</note_offsets>
+    
+
+</settings>

--- a/tests/test_usersettings.py
+++ b/tests/test_usersettings.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+
+import sys
+sys.path.append('./')
+sys.path.append('../')
+import os
+import unittest
+from lib.usersettings import UserSettings
+
+
+class TestUserSettings(unittest.TestCase):
+    def load_usersettings(self, default_file="default-test1.xml"):
+        self.us = UserSettings(self.config_path + "settings-test.xml", self.config_path + default_file)
+
+    def setUp(self):
+        abspath = os.path.abspath(__file__)
+        self.config_path = os.path.dirname(abspath) + "/config-test/"
+
+        self.load_usersettings()
+        self.us.reset_to_default()
+
+        self.keys = ["screen_on", ["screen_on"], ["color_mode_settings", "VelocityRainbow", "scale"]]
+        self.orig_vals = ["1", "1", "120"]
+        self.notfound_keys = ["NotFound", ["NotFound"], ["color_mode_settings", "NotFound"], ["color_mode_settings", "NotFound1", "NotFound2"]]
+
+    def test_01_get(self):
+        for i,k in enumerate(self.keys):
+            self.assertEqual(self.us.get(k), self.orig_vals[i])
+            self.assertEqual(self.us.get_setting_value(k), self.orig_vals[i])
+            self.assertEqual(self.us[k], self.orig_vals[i])
+
+    def test_02_set(self):
+        for k in self.keys:
+            old = self.us.get(k)
+
+            self.us.change_setting_value(k, "888")
+            self.assertEqual(self.us.get(k), "888")
+
+            self.us[k] = "999"
+            self.assertEqual(self.us.get(k), "999")
+
+            self.us.set(k, old)
+            self.assertEqual(self.us.get(k), old)
+    
+    def test_03_get_dict(self):
+        key = "VelocityRainbow"
+        val = {'offset': '210', 'scale': '120', 'curve': '0'}
+
+        get1 = self.us.get(["color_mode_settings", key])
+        get2 = self.us.get_cms(key)
+
+        self.assertEqual(get1, get2)
+        self.assertEqual(get1, val)
+
+    def test_04_get_notfound(self):
+        for k in self.notfound_keys:
+            self.assertIsNone(self.us.get(k))
+            with self.assertRaises(Exception):
+                self.us[k]
+        
+    def test_05_set_notfound(self):
+        for k in self.notfound_keys:
+            with self.assertRaises(Exception):
+                self.us.set(k, "error")
+                self.us[k] = "error"
+
+    def test_06_save(self):
+        for k in self.keys:
+            old = self.us.get(k)
+
+            self.us.set(k, "000")
+            self.us.save_changes()
+
+            self.load_usersettings()
+            self.assertEqual(self.us.get(k), "000", "Setting not saved to file.")
+
+            self.us.set(k, old)
+            self.us.save_changes()
+            self.assertEqual(self.us.get(k), old)    
+
+    def test_07_missing(self):
+        self.load_usersettings("default-test1.xml")
+        self.us.reset_to_default()
+        self.assertIsNone(self.us.get("missing"))
+        self.load_usersettings("default-test2.xml")
+
+        self.assertEqual(self.us.get("missing"), "miss1")
+        self.assertEqual(self.us.get("missing_nest"), {"sub": "sub"})
+        self.assertEqual(self.us.get(["color_mode_settings", "VelocityRainbow", "missing"]), "miss2")
+        self.assertEqual(self.us.get(["color_mode_settings", "missing_color_mode", "param"]), "1")
+
+        self.assertEqual(self.us.get_cms("VelocityRainbow", "offset"), "210")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Support nested UserSettings for eventual color_mode_settings structure.
Adjusted to copy missing defaults on initialization rather than inserting unknown settings during run-time.

On a side note, any objections if I were to change the settings file format to say, YAML, rather than XML at some point in the future?
It could make things easier code-wise -- just serialize and de-serialize dict.
