### PR TITLE
fix: Fixes some midi file issues

### DIFF
--- a/lib/learnmidi.py
+++ b/lib/learnmidi.py
@@ -197,7 +197,7 @@ class LearnMIDI:
                 offset = 0
             for k in range(len(mid.tracks)):
                 for msg in mid.tracks[k]:
-                    if not msg.is_meta:
+                    if not msg.is_meta and msg.type in ['note_on', 'note_off']:
                         msg.channel = k + offset
                         if msg.type == 'note_off':
                             msg.velocity = 0

--- a/lib/learnmidi.py
+++ b/lib/learnmidi.py
@@ -183,7 +183,7 @@ class LearnMIDI:
 
         try:
             # Load the midi file
-            mid = mido.MidiFile('Songs/' + song_path)
+            mid = mido.MidiFile('Songs/' + song_path, clip=True) # clip=True fixes some midi files
 
             # Get tempo and Ticks per beat
             self.song_tempo = get_tempo(mid)


### PR DESCRIPTION
Adds clip option to mido to fix some midi file errors such as:

```
Jan 19 11:52:01 pianoledvisualizer sudo[646]: [2024-01-19 11:52:01] INFO - Cache nor found
Jan 19 11:52:01 pianoledvisualizer sudo[646]: INFO:my_app:Cache nor found
Jan 19 11:52:02 pianoledvisualizer sudo[646]: [2024-01-19 11:52:02] WARNING - data byte must be in range 0..127
Jan 19 11:52:02 pianoledvisualizer sudo[646]: WARNING:my_app:data byte must be in range 0..127
```

Adds check for message type to fix errors such as:
```
Jan 19 13:25:29 pianoledvisualizer sudo[646]: [2024-01-19 13:25:29] INFO - Cache nor found
Jan 19 13:25:29 pianoledvisualizer sudo[646]: INFO:my_app:Cache nor found
Jan 19 13:25:42 pianoledvisualizer sudo[646]: [2024-01-19 13:25:42] WARNING - sysex message has no attribute channel
Jan 19 13:25:42 pianoledvisualizer sudo[646]: WARNING:my_app:sysex message has no attribute channel
```

Tested with the following files:
[Secret Base - Kenzie Smith Piano [Dual Track].mid.zip](https://github.com/onlaj/Piano-LED-Visualizer/files/13989834/Secret.Base.-.Kenzie.Smith.Piano.Dual.Track.mid.zip) (first error)


[Joe_Hisaishi_-_Merry_Go_Round_Of_Life_(Howls_Moving_Castle)__AniG_20091101183113.mid.zip](https://github.com/onlaj/Piano-LED-Visualizer/files/13989840/Joe_Hisaishi_-_Merry_Go_Round_Of_Life_.Howls_Moving_Castle.__AniG_20091101183113.mid.zip) (second error)

