### PR TITLE
Fade - Pedal: Optional drop strength on note release

### DIFF
--- a/config/default_settings.xml
+++ b/config/default_settings.xml
@@ -10,6 +10,7 @@
 	<blue>255</blue>
 
 	<fadingspeed>1000</fadingspeed>
+	<fadepedal_notedrop>0</fadepedal_notedrop>
 	<color_mode>Single</color_mode>
 
 	<rainbow_offset>0</rainbow_offset>

--- a/lib/ledsettings.py
+++ b/lib/ledsettings.py
@@ -23,6 +23,7 @@ class LedSettings:
         self.blue = int(usersettings.get_setting_value("blue"))
         self.mode = usersettings.get_setting_value("mode")
         self.fadingspeed = int(usersettings.get_setting_value("fadingspeed"))
+        self.fadepedal_notedrop = int(usersettings.get_setting_value("fadepedal_notedrop"))
         self.color_mode = usersettings.get_setting_value("color_mode")
         self.rainbow_offset = int(usersettings.get_setting_value("rainbow_offset"))
         self.rainbow_scale = int(usersettings.get_setting_value("rainbow_scale"))

--- a/visualizer.py
+++ b/visualizer.py
@@ -383,6 +383,8 @@ while True:
                 ledstrip.keylist[note_position] = 1000
             elif ledsettings.mode == "Normal":
                 ledstrip.keylist[note_position] = 0
+            elif ledsettings.mode == "Pedal":
+                ledstrip.keylist[note_position] *= (100 - ledsettings.fadepedal_notedrop)/100
 
             if ledstrip.keylist[note_position] <= 0:
                 if ledsettings.backlight_brightness > 0 and menu.screensaver_is_running is not True:


### PR DESCRIPTION
For Fade mode "Pedal", a visual cue when note has been released by dropping the brightness by a configurable amount.

No UI configuration yet.
I've been using "30" to good effect.
