### PR TITLE
Add Hide Note Button and show notes to play when making mistake

### DIFF
--- a/config/default_settings.xml
+++ b/config/default_settings.xml
@@ -111,11 +111,15 @@
 	<hand_colorList>[[0, 255, 0], [0, 0, 255], [255, 128, 0], [255, 255, 0], [0, 255, 255], [255, 0, 255], [255, 0, 0], [255, 255, 255], [0, 0, 0]]</hand_colorList>
 	<hand_colorR>0</hand_colorR>
 	<hand_colorL>1</hand_colorL>
+	<prev_hand_colorR>0</prev_hand_colorR>
+	<prev_hand_colorL>1</prev_hand_colorL>
     <number_of_mistakes>0</number_of_mistakes>
 
     <show_wrong_notes>1</show_wrong_notes>
     <show_future_notes>1</show_future_notes>
 	<is_loop_active>1</is_loop_active>
+	<is_left_led_active>1</is_left_led_active>
+	<is_right_led_active>1</is_right_led_active>
     <midi_logging>0</midi_logging>
     <is_hotspot_active>1</is_hotspot_active>
 

--- a/config/default_settings.xml
+++ b/config/default_settings.xml
@@ -118,8 +118,8 @@
     <show_wrong_notes>1</show_wrong_notes>
     <show_future_notes>1</show_future_notes>
 	<is_loop_active>1</is_loop_active>
-	<is_left_led_active>1</is_left_led_active>
-	<is_right_led_active>1</is_right_led_active>
+	<is_led_activeL>1</is_led_activeL>
+	<is_led_activeR>1</is_led_activeR>
     <midi_logging>0</midi_logging>
     <is_hotspot_active>1</is_hotspot_active>
 

--- a/lib/learnmidi.py
+++ b/lib/learnmidi.py
@@ -46,6 +46,8 @@ class LearnMIDI:
         self.set_tempo = int(usersettings.get_setting_value("set_tempo"))
         self.hand_colorR = int(usersettings.get_setting_value("hand_colorR"))
         self.hand_colorL = int(usersettings.get_setting_value("hand_colorL"))
+        self.prev_hand_colorR = int(usersettings.get_setting_value("prev_hand_colorR"))
+        self.prev_hand_colorL = int(usersettings.get_setting_value("prev_hand_colorL"))
 
         self.show_wrong_notes = int(usersettings.get_setting_value("show_wrong_notes"))
         self.show_future_notes = int(usersettings.get_setting_value("show_future_notes"))
@@ -60,6 +62,9 @@ class LearnMIDI:
         self.next_note_delay = None
 
         self.is_loop_active = int(usersettings.get_setting_value("is_loop_active"))
+        
+        self.is_left_led_active = int(usersettings.get_setting_value("is_left_led_active"))
+        self.is_right_led_active = int(usersettings.get_setting_value("is_right_led_active"))
 
         self.loadingList = ['', 'Load..', 'Proces', 'Merge', 'Done', 'Error!']
         self.learningList = ['Start', 'Stop']

--- a/lib/learnmidi.py
+++ b/lib/learnmidi.py
@@ -292,7 +292,7 @@ class LearnMIDI:
         if self.show_wrong_notes != 1:
             return
 
-        brightness = 0.5
+        brightness = 0.05
         # loop through wrong_notes and light them up
         for msg in wrong_notes:
             note = int(find_between(str(msg), "note=", " "))
@@ -308,11 +308,11 @@ class LearnMIDI:
                 self.mistakes_count += 1
                 if self.is_led_activeL == 0:
                     for expected_note in hand_hint_notesL:
-                        red, green, blue = [int(c * brightness) for c in self.hand_colorList[self.hand_colorL]]
+                        red, green, blue = [int(c * brightness) for c in self.hand_colorList[self.prev_hand_colorL]]
                         self.ledstrip.strip.setPixelColor(expected_note, Color(red, green, blue))
                 if self.is_led_activeR == 0:
                     for expected_note in hand_hint_notesR:
-                        red, green, blue = [int(c * brightness) for c in self.hand_colorList[self.hand_colorR]]
+                        red, green, blue = [int(c * brightness) for c in self.hand_colorList[self.prev_hand_colorR]]
                         self.ledstrip.strip.setPixelColor(expected_note, Color(red, green, blue))
             else:
                 self.ledstrip.strip.setPixelColor(note_position, Color(0, 0, 0))
@@ -461,22 +461,22 @@ class LearnMIDI:
                             red, green, blue = [0, 0, 0]
                             if msg.channel == 1:
                                 red, green, blue = [int(c * brightness) for c in self.hand_colorList[self.hand_colorR]]
-                                if self.is_led_activeL == 0:
-                                    if brightness > 0:
-                                        hand_hint_notesL.append(note_position)
-                                    else:
-                                        try:
-                                            hand_hint_notesL.remove(note_position)
-                                        except ValueError:
-                                            pass  # do nothing
-                            if msg.channel == 2:
-                                red, green, blue = [int(c * brightness) for c in self.hand_colorList[self.hand_colorL]]
                                 if self.is_led_activeR == 0:
                                     if brightness > 0:
                                         hand_hint_notesR.append(note_position)
                                     else:
                                         try:
                                             hand_hint_notesR.remove(note_position)
+                                        except ValueError:
+                                            pass  # do nothing
+                            if msg.channel == 2:
+                                red, green, blue = [int(c * brightness) for c in self.hand_colorList[self.hand_colorL]]
+                                if self.is_led_activeL == 0:
+                                    if brightness > 0:
+                                        hand_hint_notesL.append(note_position)
+                                    else:
+                                        try:
+                                            hand_hint_notesL.remove(note_position)
                                         except ValueError:
                                             pass  # do nothing
                             self.ledstrip.strip.setPixelColor(note_position, Color(red, green, blue))

--- a/lib/learnmidi.py
+++ b/lib/learnmidi.py
@@ -63,8 +63,8 @@ class LearnMIDI:
 
         self.is_loop_active = int(usersettings.get_setting_value("is_loop_active"))
         
-        self.is_left_led_active = int(usersettings.get_setting_value("is_left_led_active"))
-        self.is_right_led_active = int(usersettings.get_setting_value("is_right_led_active"))
+        self.is_led_activeL = int(usersettings.get_setting_value("is_led_activeL"))
+        self.is_led_activeR = int(usersettings.get_setting_value("is_led_activeR"))
 
         self.loadingList = ['', 'Load..', 'Proces', 'Merge', 'Done', 'Error!']
         self.learningList = ['Start', 'Stop']
@@ -287,11 +287,12 @@ class LearnMIDI:
                     self.ledstrip.strip.setPixelColor(note_position, Color(red, green, blue))
                     self.ledstrip.strip.show()
 
-    def handle_wrong_notes(self, wrong_notes):
+    def handle_wrong_notes(self, wrong_notes, hand_hint_notesL, hand_hint_notesR):
 
         if self.show_wrong_notes != 1:
             return
 
+        brightness = 0.5
         # loop through wrong_notes and light them up
         for msg in wrong_notes:
             note = int(find_between(str(msg), "note=", " "))
@@ -305,6 +306,14 @@ class LearnMIDI:
             if velocity > 0:
                 self.ledstrip.strip.setPixelColor(note_position, Color(255, 0, 0))
                 self.mistakes_count += 1
+                if self.is_led_activeL == 0:
+                    for expected_note in hand_hint_notesL:
+                        red, green, blue = [int(c * brightness) for c in self.hand_colorList[self.hand_colorL]]
+                        self.ledstrip.strip.setPixelColor(expected_note, Color(red, green, blue))
+                if self.is_led_activeR == 0:
+                    for expected_note in hand_hint_notesR:
+                        red, green, blue = [int(c * brightness) for c in self.hand_colorList[self.hand_colorR]]
+                        self.ledstrip.strip.setPixelColor(expected_note, Color(red, green, blue))
             else:
                 self.ledstrip.strip.setPixelColor(note_position, Color(0, 0, 0))
 
@@ -333,6 +342,8 @@ class LearnMIDI:
             return
 
         self.t = threading.currentThread()
+        hand_hint_notesL = []
+        hand_hint_notesR = []
 
         keep_looping = True
         while keep_looping:
@@ -411,13 +422,15 @@ class LearnMIDI:
                                         except ValueError:
                                             pass  # do nothing
 
-                                self.handle_wrong_notes(wrong_notes)
+                                self.handle_wrong_notes(wrong_notes, hand_hint_notesL, hand_hint_notesR)
                                 wrong_notes.clear()
 
                                 # light up predicted future notes again in case the future note was pressed
                                 # and color was overwritten
                                 self.predict_future_notes(absolute_idx, end_idx, notes_to_press)
-
+                            
+                            hand_hint_notesL = []
+                            hand_hint_notesR = []
                             # Play any pending software notes only after all required notes have been pressed
                             if set(notes_to_press).issubset(notes_pressed) and self.pending_software_notes:
                                 for software_note in self.pending_software_notes:
@@ -448,11 +461,26 @@ class LearnMIDI:
                             red, green, blue = [0, 0, 0]
                             if msg.channel == 1:
                                 red, green, blue = [int(c * brightness) for c in self.hand_colorList[self.hand_colorR]]
+                                if self.is_led_activeL == 0:
+                                    if brightness > 0:
+                                        hand_hint_notesL.append(note_position)
+                                    else:
+                                        try:
+                                            hand_hint_notesL.remove(note_position)
+                                        except ValueError:
+                                            pass  # do nothing
                             if msg.channel == 2:
                                 red, green, blue = [int(c * brightness) for c in self.hand_colorList[self.hand_colorL]]
+                                if self.is_led_activeR == 0:
+                                    if brightness > 0:
+                                        hand_hint_notesR.append(note_position)
+                                    else:
+                                        try:
+                                            hand_hint_notesR.remove(note_position)
+                                        except ValueError:
+                                            pass  # do nothing
                             self.ledstrip.strip.setPixelColor(note_position, Color(red, green, blue))
                             self.ledstrip.strip.show()
-
                         # Save notes to press
                         if msg.type == 'note_on' and msg.velocity > 0 and (
                                 msg.channel == self.hands or self.hands == 0):

--- a/webinterface/static/js/ui.js
+++ b/webinterface/static/js/ui.js
@@ -1081,9 +1081,16 @@ function get_learning_status(loop_call = false) {
                 
                 if (response["is_left_led_active"] === 1) {
                     document.getElementById("is_left_led_active").checked = true;
+                } else {
+                    document.getElementById("is_left_led_active").checked = false;
+                    document.getElementById("hand_colorL").style.fill = 'rgb(0,0,0)';
                 }
+
                 if (response["is_right_led_active"] === 1) {
                     document.getElementById("is_right_led_active").checked = true;
+                } else {
+                    document.getElementById("is_right_led_active").checked = false;
+                    document.getElementById("hand_colorR").style.fill = 'rgb(0,0,0)';
                 }
             }
 

--- a/webinterface/static/js/ui.js
+++ b/webinterface/static/js/ui.js
@@ -1079,17 +1079,17 @@ function get_learning_status(loop_call = false) {
                     '   document.getElementById(\'end_point\').innerHTML = this.value">\n' +
                     '</div>';
                 
-                if (response["is_left_led_active"] === 1) {
-                    document.getElementById("is_left_led_active").checked = true;
+                if (response["is_led_activeL"] === 1) {
+                    document.getElementById("is_led_activeL").checked = true;
                 } else {
-                    document.getElementById("is_left_led_active").checked = false;
+                    document.getElementById("is_led_activeL").checked = false;
                     document.getElementById("hand_colorL").style.fill = 'rgb(0,0,0)';
                 }
 
-                if (response["is_right_led_active"] === 1) {
-                    document.getElementById("is_right_led_active").checked = true;
+                if (response["is_led_activeR"] === 1) {
+                    document.getElementById("is_led_activeR").checked = true;
                 } else {
-                    document.getElementById("is_right_led_active").checked = false;
+                    document.getElementById("is_led_activeR").checked = false;
                     document.getElementById("hand_colorR").style.fill = 'rgb(0,0,0)';
                 }
             }

--- a/webinterface/static/js/ui.js
+++ b/webinterface/static/js/ui.js
@@ -1078,6 +1078,13 @@ function get_learning_status(loop_call = false) {
                     '   oninput="show_right_slider(this)" onchange="change_setting(\'learning_end_point\', this.value);\n' +
                     '   document.getElementById(\'end_point\').innerHTML = this.value">\n' +
                     '</div>';
+                
+                if (response["is_left_led_active"] === 1) {
+                    document.getElementById("is_left_led_active").checked = true;
+                }
+                if (response["is_right_led_active"] === 1) {
+                    document.getElementById("is_right_led_active").checked = true;
+                }
             }
 
         }

--- a/webinterface/templates/songs.html
+++ b/webinterface/templates/songs.html
@@ -615,6 +615,14 @@
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
                         </svg>
                     </div>
+                    <div class="justify-center flex">
+                        <label class="uppercase tracking-wide text-xs font-bold mt-2 text-gray-600 dark:text-gray-400">
+                            <input id="is_left_led_active" onchange="change_setting('change_left_led_active', this.checked)"
+                                class="w-4 h-4 mr-2 border border-gray-300 rounded"
+                                type="checkbox"/>
+                            <div class="inline" data-translate="active">Active</div>
+                        </label>
+                    </div>
                 </div>
 
                 <div class="w-full md:w-1/2 px-3 m-auto">
@@ -636,6 +644,14 @@
                              class="h-6 w-6 cursor-pointer" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
                         </svg>
+                    </div>
+                    <div class="justify-center flex">
+                        <label class="uppercase tracking-wide text-xs font-bold mt-2 text-gray-600 dark:text-gray-400">
+                            <input id="is_right_led_active" onchange="change_setting('change_right_led_active', this.checked)"
+                                class="w-4 h-4 mr-2 border border-gray-300 rounded"
+                                type="checkbox"/>
+                            <div class="inline" data-translate="active">Active</div>
+                        </label>
                     </div>
                 </div>
             </div>

--- a/webinterface/templates/songs.html
+++ b/webinterface/templates/songs.html
@@ -617,7 +617,7 @@
                     </div>
                     <div class="justify-center flex">
                         <label class="uppercase tracking-wide text-xs font-bold mt-2 text-gray-600 dark:text-gray-400">
-                            <input id="is_left_led_active" onchange="change_setting('change_left_led_active', this.checked)"
+                            <input id="is_led_activeL" onchange="change_setting('change_left_led_active', this.checked)"
                                 class="w-4 h-4 mr-2 border border-gray-300 rounded"
                                 type="checkbox"/>
                             <div class="inline" data-translate="active">Active</div>
@@ -647,7 +647,7 @@
                     </div>
                     <div class="justify-center flex">
                         <label class="uppercase tracking-wide text-xs font-bold mt-2 text-gray-600 dark:text-gray-400">
-                            <input id="is_right_led_active" onchange="change_setting('change_right_led_active', this.checked)"
+                            <input id="is_led_activeR" onchange="change_setting('change_right_led_active', this.checked)"
                                 class="w-4 h-4 mr-2 border border-gray-300 rounded"
                                 type="checkbox"/>
                             <div class="inline" data-translate="active">Active</div>

--- a/webinterface/views_api.py
+++ b/webinterface/views_api.py
@@ -1196,19 +1196,21 @@ def change_setting():
 
     if setting_name == "change_handL_color":
         value = int(value)
-        app_state.learning.hand_colorL += value
-        app_state.learning.hand_colorL = clamp(app_state.learning.hand_colorL, 0,
-                                                  len(app_state.learning.hand_colorList) - 1)
-        app_state.usersettings.change_setting_value("hand_colorL", app_state.learning.hand_colorL)
+        if app_state.learning.is_left_led_active == 1:
+            app_state.learning.hand_colorL += value
+            app_state.learning.hand_colorL = clamp(app_state.learning.hand_colorL, 0,
+                                                    len(app_state.learning.hand_colorList) - 1)
+            app_state.usersettings.change_setting_value("hand_colorL", app_state.learning.hand_colorL)
 
         return jsonify(success=True, reload_learning_settings=True)
 
     if setting_name == "change_handR_color":
         value = int(value)
-        app_state.learning.hand_colorR += value
-        app_state.learning.hand_colorR = clamp(app_state.learning.hand_colorR, 0,
-                                                  len(app_state.learning.hand_colorList) - 1)
-        app_state.usersettings.change_setting_value("hand_colorR", app_state.learning.hand_colorR)
+        if app_state.learning.is_right_led_active == 1:
+            app_state.learning.hand_colorR += value
+            app_state.learning.hand_colorR = clamp(app_state.learning.hand_colorR, 0,
+                                                    len(app_state.learning.hand_colorList) - 1)
+            app_state.usersettings.change_setting_value("hand_colorR", app_state.learning.hand_colorR)
 
         return jsonify(success=True, reload_learning_settings=True)
 
@@ -1235,6 +1237,36 @@ def change_setting():
         app_state.usersettings.change_setting_value("number_of_mistakes", app_state.learning.number_of_mistakes)
 
         return jsonify(success=True)
+
+    if setting_name == "change_left_led_active":
+        value = int(value == 'true')
+        app_state.learning.is_left_led_active = value
+        app_state.usersettings.change_setting_value("is_left_led_active", app_state.learning.is_left_led_active)
+        if value == 0:
+            app_state.learning.prev_hand_colorL = app_state.learning.hand_colorL
+            app_state.usersettings.change_setting_value("prev_hand_colorL", app_state.learning.hand_colorL)
+            app_state.learning.hand_colorL = 8
+            app_state.usersettings.change_setting_value("hand_colorL", 8)
+        else:
+            app_state.usersettings.change_setting_value("hand_colorL", app_state.learning.prev_hand_colorL)
+            app_state.learning.hand_colorL = app_state.learning.prev_hand_colorL
+        
+        return jsonify(success=True, reload_learning_settings=True)
+
+    if setting_name == "change_right_led_active":
+        value = int(value == 'true')
+        app_state.learning.is_right_led_active = value
+        app_state.usersettings.change_setting_value("is_right_led_active", app_state.learning.is_right_led_active)
+        if value == 0:
+            app_state.learning.prev_hand_colorR = app_state.learning.hand_colorR
+            app_state.usersettings.change_setting_value("prev_hand_colorR", app_state.learning.hand_colorR)
+            app_state.learning.hand_colorR = 8
+            app_state.usersettings.change_setting_value("hand_colorR", 8)
+        else:
+            app_state.usersettings.change_setting_value("hand_colorR", app_state.learning.prev_hand_colorR)
+            app_state.learning.hand_colorR = app_state.learning.prev_hand_colorR
+        
+        return jsonify(success=True, reload_learning_settings=True)
 
     if setting_name == "connect_to_wifi":
         logger.info("Controller: connecting to wifi")
@@ -1496,11 +1528,15 @@ def get_learning_status():
                 "set_tempo": app_state.usersettings.get_setting_value("set_tempo"),
                 "hand_colorR": app_state.usersettings.get_setting_value("hand_colorR"),
                 "hand_colorL": app_state.usersettings.get_setting_value("hand_colorL"),
+                "prev_hand_colorR": app_state.usersettings.get_setting_value("prev_hand_colorR"),
+                "prev_hand_colorL": app_state.usersettings.get_setting_value("prev_hand_colorL"),
                 "show_wrong_notes": app_state.usersettings.get_setting_value("show_wrong_notes"),
                 "show_future_notes": app_state.usersettings.get_setting_value("show_future_notes"),
                 "hand_colorList": ast.literal_eval(app_state.usersettings.get_setting_value("hand_colorList")),
                 "is_loop_active": ast.literal_eval(app_state.usersettings.get_setting_value("is_loop_active")),
-                "number_of_mistakes": ast.literal_eval(app_state.usersettings.get_setting_value("number_of_mistakes"))}
+                "number_of_mistakes": ast.literal_eval(app_state.usersettings.get_setting_value("number_of_mistakes")),
+                "is_left_led_active": ast.literal_eval(app_state.usersettings.get_setting_value("is_left_led_active")),
+                "is_right_led_active": ast.literal_eval(app_state.usersettings.get_setting_value("is_right_led_active"))}
 
     return jsonify(response)
 

--- a/webinterface/views_api.py
+++ b/webinterface/views_api.py
@@ -1196,7 +1196,7 @@ def change_setting():
 
     if setting_name == "change_handL_color":
         value = int(value)
-        if app_state.learning.is_left_led_active == 1:
+        if app_state.learning.is_led_activeL == 1:
             app_state.learning.hand_colorL += value
             app_state.learning.hand_colorL = clamp(app_state.learning.hand_colorL, 0,
                                                     len(app_state.learning.hand_colorList) - 1)
@@ -1206,7 +1206,7 @@ def change_setting():
 
     if setting_name == "change_handR_color":
         value = int(value)
-        if app_state.learning.is_right_led_active == 1:
+        if app_state.learning.is_led_activeR == 1:
             app_state.learning.hand_colorR += value
             app_state.learning.hand_colorR = clamp(app_state.learning.hand_colorR, 0,
                                                     len(app_state.learning.hand_colorList) - 1)
@@ -1240,8 +1240,8 @@ def change_setting():
 
     if setting_name == "change_left_led_active":
         value = int(value == 'true')
-        app_state.learning.is_left_led_active = value
-        app_state.usersettings.change_setting_value("is_left_led_active", app_state.learning.is_left_led_active)
+        app_state.learning.is_led_activeL = value
+        app_state.usersettings.change_setting_value("is_led_activeL", app_state.learning.is_led_activeL)
         if value == 0:
             app_state.learning.prev_hand_colorL = app_state.learning.hand_colorL
             app_state.usersettings.change_setting_value("prev_hand_colorL", app_state.learning.hand_colorL)
@@ -1255,8 +1255,8 @@ def change_setting():
 
     if setting_name == "change_right_led_active":
         value = int(value == 'true')
-        app_state.learning.is_right_led_active = value
-        app_state.usersettings.change_setting_value("is_right_led_active", app_state.learning.is_right_led_active)
+        app_state.learning.is_led_activeR = value
+        app_state.usersettings.change_setting_value("is_led_activeR", app_state.learning.is_led_activeR)
         if value == 0:
             app_state.learning.prev_hand_colorR = app_state.learning.hand_colorR
             app_state.usersettings.change_setting_value("prev_hand_colorR", app_state.learning.hand_colorR)
@@ -1535,8 +1535,8 @@ def get_learning_status():
                 "hand_colorList": ast.literal_eval(app_state.usersettings.get_setting_value("hand_colorList")),
                 "is_loop_active": ast.literal_eval(app_state.usersettings.get_setting_value("is_loop_active")),
                 "number_of_mistakes": ast.literal_eval(app_state.usersettings.get_setting_value("number_of_mistakes")),
-                "is_left_led_active": ast.literal_eval(app_state.usersettings.get_setting_value("is_left_led_active")),
-                "is_right_led_active": ast.literal_eval(app_state.usersettings.get_setting_value("is_right_led_active"))}
+                "is_led_activeL": ast.literal_eval(app_state.usersettings.get_setting_value("is_led_activeL")),
+                "is_led_activeR": ast.literal_eval(app_state.usersettings.get_setting_value("is_led_activeR"))}
 
     return jsonify(response)
 


### PR DESCRIPTION
Use Checkbox to switch on and off notes to play LEDs for each hand. Will move back to previously used color once activated again.

When making a mistake during playing when notes to play LEDs are off, the notes to play are highlighted as a hint in 0.05 brightness

Works for individual hands or both together