### PR TITLE
Turn off all LEDs when shutting down

### DIFF
--- a/visualizer.py
+++ b/visualizer.py
@@ -9,7 +9,7 @@ import time
 from lib.argument_parser import ArgumentParser
 from lib.component_initializer import ComponentInitializer
 from lib.functions import fastColorWipe, screensaver, \
-    manage_idle_animation
+    manage_idle_animation, stop_animations
 from lib.gpio_handler import GPIOHandler
 from lib.led_effects_processor import LEDEffectsProcessor
 from lib.ledsettings import LedSettings
@@ -91,6 +91,7 @@ class VisualizerApp:
 
     def handle_shutdown(self, signum, frame):
         # Turn off all LEDs before shutting down
+        stop_animations(self.component_initializer.menu)
         fastColorWipe(self.component_initializer.ledstrip.strip, True, self.component_initializer.ledsettings)
         sys.exit(0)
     


### PR DESCRIPTION
Handle SIGTERM (stopping service) and SIGNINT (Ctrl+C from command line) and turn off all the LEDs. Otherwise, any LEDs still on will stay on until the app is restarted or power is disconnected.