### PR TITLE
autoinstall.sh: pull list of apt packages into a named variable

### DIFF
--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -115,41 +115,41 @@ enable_spi_interface() {
 # Function to install required packages
 install_packages() {
   local packages=(
-      ruby
-      git
-      python3-pip
-      autotools-dev
-      libtool
+      abcmidi
       autoconf
+      autotools-dev
+      build-essential
+      fonts-freefont-ttf
+      gcc
+      git
       libasound2
+      libasound2-dev
+      libatlas-base-dev
+      libavahi-client-dev
       libavahi-client3
       libavahi-common3
       libc6
+      libdbus-1-dev
       libfmt9
       libgcc-s1
-      libstdc++6
-      python3
-      libopenblas-dev
-      libavahi-client-dev
-      libasound2-dev
-      libusb-dev
-      libdbus-1-dev
       libglib2.0-dev
-      libudev-dev
       libical-dev
-      libreadline-dev
-      libatlas-base-dev
-      libopenjp2-7
-      libtiff6
-      libjack0
       libjack-dev
-      fonts-freefont-ttf
-      gcc
+      libjack0
+      libopenblas-dev
+      libopenjp2-7
+      libreadline-dev
+      libstdc++6
+      libtiff6
+      libtool
+      libudev-dev
+      libusb-dev
       make
-      build-essential
+      python3
+      python3-pip
+      ruby
       scons
       swig
-      abcmidi
   )
   execute_command "sudo apt-get install -y ${packages[*]}" "check_internet"
 }

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -114,7 +114,10 @@ enable_spi_interface() {
 
 # Function to install required packages
 install_packages() {
-  execute_command "sudo apt-get install -y ruby git python3-pip autotools-dev libtool autoconf libasound2 libavahi-client3 libavahi-common3 libc6 libfmt9 libgcc-s1 libstdc++6 python3 libopenblas-dev libavahi-client-dev libasound2-dev libusb-dev libdbus-1-dev libglib2.0-dev libudev-dev libical-dev libreadline-dev libatlas-base-dev libopenjp2-7 libtiff6 libjack0 libjack-dev fonts-freefont-ttf gcc make build-essential scons swig abcmidi" "check_internet"
+  local packages=(
+      ruby git python3-pip autotools-dev libtool autoconf libasound2 libavahi-client3 libavahi-common3 libc6 libfmt9 libgcc-s1 libstdc++6 python3 libopenblas-dev libavahi-client-dev libasound2-dev libusb-dev libdbus-1-dev libglib2.0-dev libudev-dev libical-dev libreadline-dev libatlas-base-dev libopenjp2-7 libtiff6 libjack0 libjack-dev fonts-freefont-ttf gcc make build-essential scons swig abcmidi
+  )
+  execute_command "sudo apt-get install -y ${packages[*]}" "check_internet"
 }
 
 # Function to disable audio output

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -115,7 +115,41 @@ enable_spi_interface() {
 # Function to install required packages
 install_packages() {
   local packages=(
-      ruby git python3-pip autotools-dev libtool autoconf libasound2 libavahi-client3 libavahi-common3 libc6 libfmt9 libgcc-s1 libstdc++6 python3 libopenblas-dev libavahi-client-dev libasound2-dev libusb-dev libdbus-1-dev libglib2.0-dev libudev-dev libical-dev libreadline-dev libatlas-base-dev libopenjp2-7 libtiff6 libjack0 libjack-dev fonts-freefont-ttf gcc make build-essential scons swig abcmidi
+      ruby
+      git
+      python3-pip
+      autotools-dev
+      libtool
+      autoconf
+      libasound2
+      libavahi-client3
+      libavahi-common3
+      libc6
+      libfmt9
+      libgcc-s1
+      libstdc++6
+      python3
+      libopenblas-dev
+      libavahi-client-dev
+      libasound2-dev
+      libusb-dev
+      libdbus-1-dev
+      libglib2.0-dev
+      libudev-dev
+      libical-dev
+      libreadline-dev
+      libatlas-base-dev
+      libopenjp2-7
+      libtiff6
+      libjack0
+      libjack-dev
+      fonts-freefont-ttf
+      gcc
+      make
+      build-essential
+      scons
+      swig
+      abcmidi
   )
   execute_command "sudo apt-get install -y ${packages[*]}" "check_internet"
 }


### PR DESCRIPTION
This PR changes the syntax around the `sudo apt install` invocation. It pulls the list of packages out into a named variable, adds newlines between entries, and sorts the entries.