### PR TITLE
Add live estimated LED power draw to the LED Settings page

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Notice, that you won't be able to use web interface
 
 **Q - How much current do my LEDs draw?**
 
-- The homepage shows an **estimated LED draw** (amps and watts), calculated live from the colors currently on the strip — no meter needed. Because draw varies by LED chip/strip, tune the three inputs on that card to match yours: **mA/ch** (per-color current at full, ~20 mA for WS2812B), **idle mA** (per-LED quiescent, ~1 mA), and **Volts** (supply, usually 5). It's an estimate of commanded output, not a measurement.
+- The **LED Settings** page shows an **estimated LED draw** (amps and watts), calculated live from the colors currently on the strip — no meter needed, and it updates as you adjust brightness/colors. Because draw varies by LED chip/strip, tune the three inputs on that card to match yours: **mA/ch** (per-color current at full, ~20 mA for WS2812B), **idle mA** (per-LED quiescent, ~1 mA), and **Volts** (supply, usually 5). It's an estimate of commanded output, not a measurement.
 
 **Q - Do I need soldering skills to make it?**
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ Notice, that you won't be able to use web interface
 
 - RPi alone should be fine powering up to 10 LEDs at the same time, although I do not recommend it.
 
+**Q - How much current do my LEDs draw?**
+
+- The homepage shows an **estimated LED draw** (amps and watts), calculated live from the colors currently on the strip — no meter needed. Because draw varies by LED chip/strip, tune the three inputs on that card to match yours: **mA/ch** (per-color current at full, ~20 mA for WS2812B), **idle mA** (per-LED quiescent, ~1 mA), and **Volts** (supply, usually 5). It's an estimate of commanded output, not a measurement.
+
 **Q - Do I need soldering skills to make it?**
 
 - Users reported that LED strips bought on Amazon are shipped in one meter strips, in that case you would need to solder them. I bought mine on Aliexpress and it was 2 meters long strip in one piece. As for connecting wires to RPi, I just wrapped them around pins and tightened it with heat shrink bands.

--- a/config/default_settings.xml
+++ b/config/default_settings.xml
@@ -147,6 +147,11 @@
 	<led_pin>18</led_pin>
 	<led_channel>0</led_channel>
 
+	<!-- LED power estimate (tune to your strip; shown on the dashboard) -->
+	<led_ma_per_channel>20</led_ma_per_channel>
+	<led_idle_ma>1</led_idle_ma>
+	<led_supply_voltage>5</led_supply_voltage>
+
     <hotspot_password>visualizer</hotspot_password>
 
     <web_listen_ip></web_listen_ip>

--- a/webinterface/static/index.js
+++ b/webinterface/static/index.js
@@ -36,7 +36,8 @@ function loadAjax(subpage) {
     }
 
     const mainElement = document.getElementById("main");
-    
+    clearInterval(window.led_power_interval);
+
     // Restore padding if leaving practice tab
     if (current_page === "practice" && subpage !== "practice") {
         mainElement.classList.add("p-5");
@@ -75,6 +76,8 @@ function loadAjax(subpage) {
                         initialize_led_settings();
                         get_current_sequence_setting();
                         clearInterval(homepage_interval);
+                        get_led_power_loop();
+                        window.led_power_interval = setInterval(get_led_power_loop, 1500);
                         setAdvancedMode(advancedMode);
                         if(typeof get_presets === 'function') {
                             get_presets();

--- a/webinterface/static/js/ui.js
+++ b/webinterface/static/js/ui.js
@@ -117,28 +117,6 @@ function get_homepage_data_loop() {
             if (cardUsagePercentEl) {
                 cardUsagePercentEl.innerHTML = response_pc_stats["card_space_percent"] + "%";
             }
-
-            // Estimated LED power draw
-            const ledCurrentEl = document.getElementById("led_current_a");
-            if (ledCurrentEl && response_pc_stats.led_current_a !== undefined) {
-                ledCurrentEl.innerHTML = Number(response_pc_stats.led_current_a).toFixed(2) + " A";
-            }
-            const ledPowerEl = document.getElementById("led_power_w");
-            if (ledPowerEl && response_pc_stats.led_power_w !== undefined) {
-                ledPowerEl.innerHTML = Number(response_pc_stats.led_power_w).toFixed(1) + " W";
-            }
-            const ledMaxEl = document.getElementById("led_current_max_a");
-            if (ledMaxEl && response_pc_stats.led_current_max_a !== undefined) {
-                ledMaxEl.innerHTML = Number(response_pc_stats.led_current_max_a).toFixed(1);
-            }
-            // Populate the per-strip tuning inputs (skip the one being edited)
-            ["led_ma_per_channel", "led_idle_ma", "led_supply_voltage"].forEach(function (id) {
-                const el = document.getElementById(id);
-                if (el && el !== document.activeElement && response_pc_stats[id] !== undefined) {
-                    el.value = response_pc_stats[id];
-                }
-            });
-
             const downloadNumberEl = document.getElementById("download_number");
             if (downloadNumberEl) {
                 animateValue(downloadNumberEl, last_download, download, refresh_rate * 500, true);
@@ -246,6 +224,28 @@ function get_homepage_data_loop() {
         }
     };
     xhttp.open("GET", "/api/get_homepage_data", true);
+    xhttp.send();
+}
+
+// Live estimated LED power draw for the LED settings page
+function get_led_power_loop() {
+    const xhttp = new XMLHttpRequest();
+    xhttp.onreadystatechange = function () {
+        if (this.readyState === 4 && this.status === 200) {
+            const d = JSON.parse(this.responseText);
+            const cur = document.getElementById("led_current_a");
+            if (cur && d.led_current_a !== undefined) cur.innerHTML = Number(d.led_current_a).toFixed(2);
+            const pw = document.getElementById("led_power_w");
+            if (pw && d.led_power_w !== undefined) pw.innerHTML = Number(d.led_power_w).toFixed(1);
+            const mx = document.getElementById("led_current_max_a");
+            if (mx && d.led_current_max_a !== undefined) mx.innerHTML = Number(d.led_current_max_a).toFixed(1);
+            ["led_ma_per_channel", "led_idle_ma", "led_supply_voltage"].forEach(function (id) {
+                const el = document.getElementById(id);
+                if (el && el !== document.activeElement && d[id] !== undefined) el.value = d[id];
+            });
+        }
+    };
+    xhttp.open("GET", "/api/get_led_power", true);
     xhttp.send();
 }
 function get_colormap_gradients() {

--- a/webinterface/static/js/ui.js
+++ b/webinterface/static/js/ui.js
@@ -117,6 +117,28 @@ function get_homepage_data_loop() {
             if (cardUsagePercentEl) {
                 cardUsagePercentEl.innerHTML = response_pc_stats["card_space_percent"] + "%";
             }
+
+            // Estimated LED power draw
+            const ledCurrentEl = document.getElementById("led_current_a");
+            if (ledCurrentEl && response_pc_stats.led_current_a !== undefined) {
+                ledCurrentEl.innerHTML = Number(response_pc_stats.led_current_a).toFixed(2) + " A";
+            }
+            const ledPowerEl = document.getElementById("led_power_w");
+            if (ledPowerEl && response_pc_stats.led_power_w !== undefined) {
+                ledPowerEl.innerHTML = Number(response_pc_stats.led_power_w).toFixed(1) + " W";
+            }
+            const ledMaxEl = document.getElementById("led_current_max_a");
+            if (ledMaxEl && response_pc_stats.led_current_max_a !== undefined) {
+                ledMaxEl.innerHTML = Number(response_pc_stats.led_current_max_a).toFixed(1);
+            }
+            // Populate the per-strip tuning inputs (skip the one being edited)
+            ["led_ma_per_channel", "led_idle_ma", "led_supply_voltage"].forEach(function (id) {
+                const el = document.getElementById(id);
+                if (el && el !== document.activeElement && response_pc_stats[id] !== undefined) {
+                    el.value = response_pc_stats[id];
+                }
+            });
+
             const downloadNumberEl = document.getElementById("download_number");
             if (downloadNumberEl) {
                 animateValue(downloadNumberEl, last_download, download, refresh_rate * 500, true);

--- a/webinterface/templates/home.html
+++ b/webinterface/templates/home.html
@@ -130,40 +130,6 @@
                 </div>
             </div>
         </a>
-        <!-- Estimated LED power draw (computed from live pixels; tune to your strip) -->
-        <a class="glass shadow-glass-lg rounded-glass hover-lift intro-y transition-smooth m-1">
-            <div class="p-3">
-                <div class="flex justify-between items-center mb-2">
-                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none"
-                         viewBox="0 0 24 24" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                              d="M13 10V3L4 14h7v7l9-11h-7z"></path>
-                    </svg>
-                    <div class="bg-green-500 rounded-full h-5 px-2 flex justify-items-center text-white font-semibold text-xs">
-                        <span id="led_power_w" class="flex items-center">-- W</span>
-                    </div>
-                </div>
-                <div id="led_current_a" class="text-xl font-bold">-.-- A</div>
-                <div class="mt-1 text-xs text-gray-600 dark:text-gray-400">
-                    <span data-translate="est_led_draw">Est. LED draw</span>
-                    <span class="opacity-70">(max <span id="led_current_max_a">--</span> A)</span>
-                </div>
-                <div class="mt-2 grid grid-cols-3 gap-1">
-                    <label class="text-[10px] text-gray-500 dark:text-gray-400">mA/ch
-                        <input id="led_ma_per_channel" type="number" min="0" step="0.5"
-                               onchange="change_setting('led_ma_per_channel', this.value)"
-                               class="w-full glass-light rounded px-1 py-0.5 text-xs"></label>
-                    <label class="text-[10px] text-gray-500 dark:text-gray-400">idle mA
-                        <input id="led_idle_ma" type="number" min="0" step="0.1"
-                               onchange="change_setting('led_idle_ma', this.value)"
-                               class="w-full glass-light rounded px-1 py-0.5 text-xs"></label>
-                    <label class="text-[10px] text-gray-500 dark:text-gray-400">Volts
-                        <input id="led_supply_voltage" type="number" min="0" step="0.1"
-                               onchange="change_setting('led_supply_voltage', this.value)"
-                               class="w-full glass-light rounded px-1 py-0.5 text-xs"></label>
-                </div>
-            </div>
-        </a>
         <a class="glass shadow-glass-lg rounded-glass hover-lift intro-y transition-smooth m-1">
             <div class="p-3">
                 <div class="flex justify-between items-center mb-2">

--- a/webinterface/templates/home.html
+++ b/webinterface/templates/home.html
@@ -130,6 +130,40 @@
                 </div>
             </div>
         </a>
+        <!-- Estimated LED power draw (computed from live pixels; tune to your strip) -->
+        <a class="glass shadow-glass-lg rounded-glass hover-lift intro-y transition-smooth m-1">
+            <div class="p-3">
+                <div class="flex justify-between items-center mb-2">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none"
+                         viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                              d="M13 10V3L4 14h7v7l9-11h-7z"></path>
+                    </svg>
+                    <div class="bg-green-500 rounded-full h-5 px-2 flex justify-items-center text-white font-semibold text-xs">
+                        <span id="led_power_w" class="flex items-center">-- W</span>
+                    </div>
+                </div>
+                <div id="led_current_a" class="text-xl font-bold">-.-- A</div>
+                <div class="mt-1 text-xs text-gray-600 dark:text-gray-400">
+                    <span data-translate="est_led_draw">Est. LED draw</span>
+                    <span class="opacity-70">(max <span id="led_current_max_a">--</span> A)</span>
+                </div>
+                <div class="mt-2 grid grid-cols-3 gap-1">
+                    <label class="text-[10px] text-gray-500 dark:text-gray-400">mA/ch
+                        <input id="led_ma_per_channel" type="number" min="0" step="0.5"
+                               onchange="change_setting('led_ma_per_channel', this.value)"
+                               class="w-full glass-light rounded px-1 py-0.5 text-xs"></label>
+                    <label class="text-[10px] text-gray-500 dark:text-gray-400">idle mA
+                        <input id="led_idle_ma" type="number" min="0" step="0.1"
+                               onchange="change_setting('led_idle_ma', this.value)"
+                               class="w-full glass-light rounded px-1 py-0.5 text-xs"></label>
+                    <label class="text-[10px] text-gray-500 dark:text-gray-400">Volts
+                        <input id="led_supply_voltage" type="number" min="0" step="0.1"
+                               onchange="change_setting('led_supply_voltage', this.value)"
+                               class="w-full glass-light rounded px-1 py-0.5 text-xs"></label>
+                </div>
+            </div>
+        </a>
         <a class="glass shadow-glass-lg rounded-glass hover-lift intro-y transition-smooth m-1">
             <div class="p-3">
                 <div class="flex justify-between items-center mb-2">

--- a/webinterface/templates/ledsettings.html
+++ b/webinterface/templates/ledsettings.html
@@ -153,6 +153,29 @@
                         <output id="brightness_percent" class="flex justify-center text-sm">50%</output>
                     </div>
                 </div>
+                <!-- Estimated LED power draw (live, from current pixels; tune to your strip) -->
+                <div class="glass-light rounded-glass p-2">
+                    <div class="flex items-center justify-between">
+                        <span class="text-xs font-semibold text-gray-600 dark:text-gray-400" data-translate="est_led_draw">Est. LED draw</span>
+                        <span class="text-sm font-bold"><span id="led_current_a">-.--</span> A
+                            <span class="text-xs font-normal text-gray-500 dark:text-gray-400">(<span id="led_power_w">--</span> W)</span></span>
+                    </div>
+                    <div class="text-[10px] text-gray-500 dark:text-gray-400 mb-2">max <span id="led_current_max_a">--</span> A (all LEDs full white)</div>
+                    <div class="grid grid-cols-3 gap-1">
+                        <label class="text-[10px] text-gray-500 dark:text-gray-400">mA/ch
+                            <input id="led_ma_per_channel" type="number" min="0" step="0.5"
+                                   onchange="change_setting('led_ma_per_channel', this.value)"
+                                   class="w-full glass-light rounded px-1 py-0.5 text-xs"></label>
+                        <label class="text-[10px] text-gray-500 dark:text-gray-400">idle mA
+                            <input id="led_idle_ma" type="number" min="0" step="0.1"
+                                   onchange="change_setting('led_idle_ma', this.value)"
+                                   class="w-full glass-light rounded px-1 py-0.5 text-xs"></label>
+                        <label class="text-[10px] text-gray-500 dark:text-gray-400">Volts
+                            <input id="led_supply_voltage" type="number" min="0" step="0.1"
+                                   onchange="change_setting('led_supply_voltage', this.value)"
+                                   class="w-full glass-light rounded px-1 py-0.5 text-xs"></label>
+                    </div>
+                </div>
                 <div>
                     <label data-translate="backlight"
                         class="block text-xs font-semibold mb-2 text-gray-600 dark:text-gray-400">Backlight</label>

--- a/webinterface/views_api.py
+++ b/webinterface/views_api.py
@@ -32,6 +32,49 @@ GPIO.setup(SENSECOVER, GPIO.IN, GPIO.PUD_UP)
 pid = psutil.Process(os.getpid())
 
 
+def estimate_led_power():
+    """Estimate LED strip current/power from the live pixel buffer (no sensor).
+
+        current ≈ N·idle_ma + (Σ subpixel/255)·ma_per_channel·(brightness/255)
+
+    The per-LED figures are user-tunable (they vary by chip/strip). This reflects
+    the values PLV is driving — an estimate, not a measurement: it ignores per-LED
+    regulation variance, voltage droop and wiring losses.
+    """
+    us = app_state.usersettings
+    try:
+        ma_per_channel = float(us.get_setting_value("led_ma_per_channel") or 20)
+        idle_ma = float(us.get_setting_value("led_idle_ma") or 1)
+        voltage = float(us.get_setting_value("led_supply_voltage") or 5)
+    except (TypeError, ValueError):
+        ma_per_channel, idle_ma, voltage = 20.0, 1.0, 5.0
+
+    strip = app_state.ledstrip.strip
+    n = strip.numPixels()
+    brightness = getattr(app_state.ledstrip, "brightness", 255) or 0
+
+    subpixel_sum = 0
+    try:
+        pixels = strip.getPixels()
+        for i in range(n):
+            c = int(pixels[i])
+            subpixel_sum += ((c >> 16) & 0xFF) + ((c >> 8) & 0xFF) + (c & 0xFF)
+    except Exception:
+        subpixel_sum = 0
+
+    lit_ma = (subpixel_sum / 255.0) * ma_per_channel * (brightness / 255.0)
+    current_a = (n * idle_ma + lit_ma) / 1000.0
+    max_a = (n * idle_ma + n * 3 * ma_per_channel) / 1000.0
+    return {
+        "led_current_a": round(current_a, 2),
+        "led_power_w": round(current_a * voltage, 1),
+        "led_current_max_a": round(max_a, 2),
+        "led_ma_per_channel": ma_per_channel,
+        "led_idle_ma": idle_ma,
+        "led_supply_voltage": voltage,
+    }
+
+
 @webinterface.route('/api/start_animation', methods=['GET'])
 def start_animation():
     choice = request.args.get('name')
@@ -165,6 +208,7 @@ def get_homepage_data():
         'led_pin': app_state.usersettings.get_setting_value("led_pin") or '18',
         'timezone': app_state.platform.get_current_timezone() if hasattr(app_state.platform, 'get_current_timezone') else 'UTC',
     }
+    homepage_data.update(estimate_led_power())
     return jsonify(homepage_data)
 
 
@@ -1678,6 +1722,14 @@ def change_setting():
         app_state.usersettings.change_setting_value("led_gamma", value)
         app_state.ledstrip.change_gamma(float(value))
 
+        return jsonify(success=True)
+
+    if setting_name in ("led_ma_per_channel", "led_idle_ma", "led_supply_voltage"):
+        try:
+            float(value)
+        except (TypeError, ValueError):
+            return jsonify(success=False, error="value must be a number")
+        app_state.usersettings.change_setting_value(setting_name, value)
         return jsonify(success=True)
 
     if setting_name == "hotspot_password":

--- a/webinterface/views_api.py
+++ b/webinterface/views_api.py
@@ -208,8 +208,13 @@ def get_homepage_data():
         'led_pin': app_state.usersettings.get_setting_value("led_pin") or '18',
         'timezone': app_state.platform.get_current_timezone() if hasattr(app_state.platform, 'get_current_timezone') else 'UTC',
     }
-    homepage_data.update(estimate_led_power())
     return jsonify(homepage_data)
+
+
+@webinterface.route('/api/get_led_power', methods=['GET'])
+def get_led_power():
+    """Live estimated LED strip current/power (polled by the LED settings page)."""
+    return jsonify(estimate_led_power())
 
 
 @webinterface.route('/api/get_timezones', methods=['GET'])


### PR DESCRIPTION
## What


https://github.com/user-attachments/assets/b0fc6be9-e4b6-4ca3-8193-fad1c926fac3



Adds an **Estimated LED draw** card to the **LED Settings** page (`#ledsettings`) showing the strip's current (A) and power (W), computed live from the pixel buffer PLV is already driving — no external meter or PSU tap required.

    current ≈ N·idle_ma + (Σ subpixel/255)·ma_per_channel·(brightness/255)

Since real draw depends on the LED chip/strip, the card has three inputs so each user can match their hardware:

- **mA/ch** — per-color-channel current at full (default 20, typical WS2812B)
- **idle mA** — per-LED quiescent current (default 1)
- **Volts** — supply voltage (default 5)

It also shows the theoretical max (all LEDs full white) as a headroom reference — handy for sizing a PSU or checking you're under budget at a given brightness.

## How it works

- `estimate_led_power()` in `views_api.py` reads `strip.getPixels()` and scales by the strip brightness; exposed on a dedicated `GET /api/get_led_power` endpoint (kept off the homepage data path so it only runs when the card is visible).
- The LED Settings page polls that endpoint every 1.5 s while the tab is open; the interval is started when the tab loads and cleared on navigation away (`ui.js` / `index.js`).
- New settings `led_ma_per_channel` / `led_idle_ma` / `led_supply_voltage` (defaults 20 / 1 / 5) in `default_settings.xml`, persisted via `change_setting`.
- Card lives in `ledsettings.html`; `ui.js` renders the values and populates the inputs (the input being edited is not clobbered).
- README FAQ entry.

It's an estimate of commanded output, not a measurement: it ignores per-LED regulation variance, voltage droop and wiring losses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
